### PR TITLE
separate webpack build and express npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Social ride network",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=production npm run build && NODE_ENV=production node ./src/main-server",
+    "start": "NODE_ENV=production node ./src/main-server",
+    "postinstall": "npm run build",
     "dev-server": "NODE_ENV=development node ./src/main-server",
     "build": "npm run clean && webpack --config ./webpack/webpack.config.js",
     "clean": "rm -rf ./build",


### PR DESCRIPTION
Heroku has a 60s timeout after executing `npm start`, since we were building our assets and starting express in the same npm script, heroku was reaching this timeout and not deploying correctly.
- This PR fixes that by creating a postinstall script to handle our webpack bundling
