### PR TITLE
Refactor rides

### DIFF
--- a/src/app/Layout/Home.elm
+++ b/src/app/Layout/Home.elm
@@ -2,7 +2,7 @@ module Layout.Home exposing (view)
 
 import Testable.Html exposing (Html, div)
 import Testable.Html.Attributes exposing (id, class)
-import Model exposing (Model, Ride)
+import Model exposing (Model)
 import Msg exposing (Msg(..))
 import Layout.Header exposing (header)
 import Instructions.Instructions exposing (instructions)
@@ -24,7 +24,7 @@ loginOrHomeScreen model =
             div [ id "app-main" ]
                 [ header
                 , instructions
-                , routesList model
+                , routesList model.rides
                 ]
 
         Nothing ->

--- a/src/app/Layout/Home.elm
+++ b/src/app/Layout/Home.elm
@@ -6,7 +6,7 @@ import Model exposing (Model, Rider)
 import Msg exposing (Msg(..))
 import Layout.Header exposing (header)
 import Instructions.Instructions exposing (instructions)
-import RoutesBox.RoutesList exposing (routesList)
+import Rides.RoutesList exposing (routesList)
 import Login.View.Login exposing (login)
 import Login.Model exposing (loggedInUser)
 

--- a/src/app/Layout/Home.elm
+++ b/src/app/Layout/Home.elm
@@ -2,7 +2,7 @@ module Layout.Home exposing (view)
 
 import Testable.Html exposing (Html, div)
 import Testable.Html.Attributes exposing (id, class)
-import Model exposing (Model, Rider)
+import Model exposing (Model, Ride)
 import Msg exposing (Msg(..))
 import Layout.Header exposing (header)
 import Instructions.Instructions exposing (instructions)

--- a/src/app/Model.elm
+++ b/src/app/Model.elm
@@ -1,24 +1,12 @@
-module Model exposing (Model, Ride, Flags, init)
+module Model exposing (Model, Flags, init)
 
 import Login.Model as Login
+import Rides.Model as Rides
 import Testable.Cmd
 
 
-type alias Ride =
-    { id : String
-    , name : String
-    , origin : String
-    , destination : String
-    , area : String
-    , days : String
-    , hours : String
-    , flexible : Bool
-    , formUrl : String
-    }
-
-
 type alias Model =
-    { rides : List Ride
+    { rides : Rides.Model
     , login : Login.Model
     }
 
@@ -30,7 +18,7 @@ type alias Flags =
 
 init : Flags -> ( Model, Testable.Cmd.Cmd a )
 init { currentUser } =
-    ( { rides = []
+    ( { rides = Rides.init
       , login = Login.init currentUser
       }
     , Testable.Cmd.none

--- a/src/app/Model.elm
+++ b/src/app/Model.elm
@@ -1,10 +1,10 @@
-module Model exposing (Model, Rider, Flags, init)
+module Model exposing (Model, Ride, Flags, init)
 
 import Login.Model as Login
 import Testable.Cmd
 
 
-type alias Rider =
+type alias Ride =
     { id : String
     , name : String
     , origin : String
@@ -18,7 +18,7 @@ type alias Rider =
 
 
 type alias Model =
-    { riders : List Rider
+    { rides : List Ride
     , login : Login.Model
     }
 
@@ -30,7 +30,7 @@ type alias Flags =
 
 init : Flags -> ( Model, Testable.Cmd.Cmd a )
 init { currentUser } =
-    ( { riders = []
+    ( { rides = []
       , login = Login.init currentUser
       }
     , Testable.Cmd.none

--- a/src/app/Msg.elm
+++ b/src/app/Msg.elm
@@ -1,9 +1,9 @@
 module Msg exposing (Msg(..))
 
-import Model exposing (Rider)
+import Model exposing (Ride)
 import Login.Msg as Login
 
 
 type Msg
-    = UpdateRiders (List Rider)
+    = UpdateRides (List Ride)
     | MsgForLogin Login.Msg

--- a/src/app/Msg.elm
+++ b/src/app/Msg.elm
@@ -1,9 +1,9 @@
 module Msg exposing (Msg(..))
 
-import Model exposing (Ride)
 import Login.Msg as Login
+import Rides.Msg as Rides
 
 
 type Msg
-    = UpdateRides (List Ride)
+    = MsgForRides Rides.Msg
     | MsgForLogin Login.Msg

--- a/src/app/Ports.elm
+++ b/src/app/Ports.elm
@@ -1,16 +1,14 @@
 port module Ports exposing (subscriptions)
 
-import Model exposing (Model, Ride)
+import Model exposing (Model)
 import Msg as Root exposing (Msg(..))
 import Login.Ports as Login
+import Rides.Ports as Rides
 
 
 subscriptions : Model -> Sub Root.Msg
 subscriptions _ =
     Sub.batch
-        [ rides UpdateRides
+        [ Sub.map MsgForRides Rides.subscriptions
         , Sub.map MsgForLogin Login.subscriptions
         ]
-
-
-port rides : (List Ride -> msg) -> Sub msg

--- a/src/app/Ports.elm
+++ b/src/app/Ports.elm
@@ -1,6 +1,6 @@
 port module Ports exposing (subscriptions)
 
-import Model exposing (Model, Rider)
+import Model exposing (Model, Ride)
 import Msg as Root exposing (Msg(..))
 import Login.Ports as Login
 
@@ -8,9 +8,9 @@ import Login.Ports as Login
 subscriptions : Model -> Sub Root.Msg
 subscriptions _ =
     Sub.batch
-        [ riders UpdateRiders
+        [ rides UpdateRides
         , Sub.map MsgForLogin Login.subscriptions
         ]
 
 
-port riders : (List Rider -> msg) -> Sub msg
+port rides : (List Ride -> msg) -> Sub msg

--- a/src/app/Rides/FeedbackBox.elm
+++ b/src/app/Rides/FeedbackBox.elm
@@ -1,4 +1,4 @@
-module RoutesBox.FeedbackBox exposing (feedbackBox)
+module Rides.FeedbackBox exposing (feedbackBox)
 
 import Testable.Html exposing (Html, div, text, h3, a)
 import Testable.Html.Attributes exposing (id, class, href, target, rel)

--- a/src/app/Rides/Model.elm
+++ b/src/app/Rides/Model.elm
@@ -1,0 +1,23 @@
+module Rides.Model exposing (Model, Ride, init)
+
+
+type alias Ride =
+    { id : String
+    , name : String
+    , origin : String
+    , destination : String
+    , area : String
+    , days : String
+    , hours : String
+    , flexible : Bool
+    , formUrl : String
+    }
+
+
+type alias Model =
+    List Ride
+
+
+init : Model
+init =
+    []

--- a/src/app/Rides/Msg.elm
+++ b/src/app/Rides/Msg.elm
@@ -1,0 +1,7 @@
+module Rides.Msg exposing (Msg(..))
+
+import Rides.Model exposing (Ride)
+
+
+type Msg
+    = UpdateRides (List Ride)

--- a/src/app/Rides/Ports.elm
+++ b/src/app/Rides/Ports.elm
@@ -1,0 +1,12 @@
+port module Rides.Ports exposing (subscriptions)
+
+import Rides.Model exposing (Ride)
+import Rides.Msg exposing (Msg(..))
+
+
+subscriptions : Sub Msg
+subscriptions =
+    rides UpdateRides
+
+
+port rides : (List Ride -> msg) -> Sub msg

--- a/src/app/Rides/RoutesList.elm
+++ b/src/app/Rides/RoutesList.elm
@@ -1,4 +1,4 @@
-module RoutesBox.RoutesList exposing (routesList)
+module Rides.RoutesList exposing (routesList)
 
 import Testable.Html exposing (Html, text, span, ol, li, a, div, strong, p, hr)
 import Testable.Html.Attributes exposing (id, class, href, target, rel)

--- a/src/app/Rides/RoutesList.elm
+++ b/src/app/Rides/RoutesList.elm
@@ -2,13 +2,13 @@ module Rides.RoutesList exposing (routesList)
 
 import Testable.Html exposing (Html, text, span, ol, li, a, div, strong, p, hr)
 import Testable.Html.Attributes exposing (id, class, href, target, rel)
-import Model exposing (Model, Ride)
+import Rides.Model exposing (Model, Ride)
 import Common.Icon exposing (icon)
 
 
 routesList : Model -> Html a
-routesList model =
-    div [ class "container" ] (List.map rideRoute model.rides)
+routesList rides =
+    div [ class "container" ] (List.map rideRoute rides)
 
 
 rideRoute : Ride -> Html a

--- a/src/app/Rides/RoutesList.elm
+++ b/src/app/Rides/RoutesList.elm
@@ -2,54 +2,54 @@ module Rides.RoutesList exposing (routesList)
 
 import Testable.Html exposing (Html, text, span, ol, li, a, div, strong, p, hr)
 import Testable.Html.Attributes exposing (id, class, href, target, rel)
-import Model exposing (Model, Rider)
+import Model exposing (Model, Ride)
 import Common.Icon exposing (icon)
 
 
 routesList : Model -> Html a
 routesList model =
-    div [ class "container" ] (List.map riderRoute model.riders)
+    div [ class "container" ] (List.map rideRoute model.rides)
 
 
-riderRoute : Rider -> Html a
-riderRoute rider =
-    a [ href rider.formUrl, target "_blank", class "card rider-card" ]
+rideRoute : Ride -> Html a
+rideRoute ride =
+    a [ href ride.formUrl, target "_blank", class "card ride-card" ]
         [ div [ class "card-content" ]
-            ([ span [ class "card-title" ] [ text rider.area ]
+            ([ span [ class "card-title" ] [ text ride.area ]
              , div [ class "ride-path" ]
                 [ p []
                     [ div [ class "icon-path" ] [ icon "more_vert" ]
                     , span [ class "icon-path-dot" ] [ icon "radio_button_unchecked" ]
-                    , text <| "Origem: " ++ rider.origin
+                    , text <| "Origem: " ++ ride.origin
                     ]
                 , p []
                     [ span [ class "icon-path-dot" ] [ icon "radio_button_unchecked" ]
-                    , text <| "Destino: " ++ rider.destination
+                    , text <| "Destino: " ++ ride.destination
                     ]
                 ]
              ]
-                ++ (flexibleRoute rider)
+                ++ (flexibleRoute ride)
             )
         , div [ class "card-action" ]
             [ p []
                 [ icon "today"
-                , text rider.days
+                , text ride.days
                 ]
             , p []
                 [ icon "schedule"
-                , text rider.hours
+                , text ride.hours
                 ]
             , p []
                 [ icon "directions_car"
-                , text rider.name
+                , text ride.name
                 ]
             ]
         ]
 
 
-flexibleRoute : Rider -> List (Html a)
-flexibleRoute rider =
-    if rider.flexible then
+flexibleRoute : Ride -> List (Html a)
+flexibleRoute ride =
+    if ride.flexible then
         [ p []
             [ icon "call_split"
             , text "Rota flexível"

--- a/src/app/Rides/Update.elm
+++ b/src/app/Rides/Update.elm
@@ -1,0 +1,11 @@
+module Rides.Update exposing (update)
+
+import Rides.Model exposing (Model)
+import Rides.Msg exposing (Msg(..))
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        UpdateRides rides ->
+            rides

--- a/src/app/Update.elm
+++ b/src/app/Update.elm
@@ -2,6 +2,7 @@ module Update exposing (update)
 
 import Model exposing (Model)
 import Login.Update as Login
+import Rides.Update as Rides
 import Msg exposing (Msg(..))
 import Testable.Cmd
 
@@ -14,8 +15,8 @@ update msg model =
 modelUpdate : Msg -> Model -> Model
 modelUpdate msg model =
     case msg of
-        UpdateRides rides ->
-            { model | rides = rides }
+        MsgForRides ridesMsg ->
+            { model | rides = Rides.update ridesMsg model.rides }
 
         MsgForLogin loginMsg ->
             { model | login = Login.update loginMsg model.login }
@@ -24,7 +25,7 @@ modelUpdate msg model =
 cmdUpdate : Msg -> Model -> Testable.Cmd.Cmd Msg
 cmdUpdate msg model =
     case msg of
-        UpdateRides rides ->
+        MsgForRides ridesMsg ->
             Testable.Cmd.none
 
         MsgForLogin loginMsg ->

--- a/src/app/Update.elm
+++ b/src/app/Update.elm
@@ -14,8 +14,8 @@ update msg model =
 modelUpdate : Msg -> Model -> Model
 modelUpdate msg model =
     case msg of
-        UpdateRiders riders ->
-            { model | riders = riders }
+        UpdateRides rides ->
+            { model | rides = rides }
 
         MsgForLogin loginMsg ->
             { model | login = Login.update loginMsg model.login }
@@ -24,7 +24,7 @@ modelUpdate msg model =
 cmdUpdate : Msg -> Model -> Testable.Cmd.Cmd Msg
 cmdUpdate msg model =
     case msg of
-        UpdateRiders riders ->
+        UpdateRides rides ->
             Testable.Cmd.none
 
         MsgForLogin loginMsg ->

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -20,7 +20,7 @@ nav {
   }
 }
 
-.rider-card {
+.ride-card {
   display: block;
   color: $primary_text_color;
   .card-title {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -12,7 +12,7 @@ firebase.initializeApp(config);
 
 var database = firebase.database();
 
-var ridersRef = firebase.database().ref('riders');
+var ridesRef = firebase.database().ref('rides');
 
 var toArrayOfObjects = function (object) {
   return Object.keys(object).reduce(function (accumulated, itemId) {
@@ -23,9 +23,9 @@ var toArrayOfObjects = function (object) {
 };
 
 module.exports = function (app) {
-  var fetchRiders = function () {
-    firebase.database().ref('riders').on('value', function (riders) {
-      app.ports.riders.send(toArrayOfObjects(riders.val()));
+  var fetchRides = function () {
+    firebase.database().ref('rides').on('value', function (rides) {
+      app.ports.rides.send(toArrayOfObjects(rides.val()));
     });
   };
 
@@ -51,7 +51,7 @@ module.exports = function (app) {
 
   var signInUser = function (user) {
     app.ports.signInResponse.send([null, {id: user.uid, name: user.displayName || ""}]);
-    fetchRiders();
+    fetchRides();
   };
 
   var signOutUser = function () {

--- a/tests/Integration/LoginSpec.elm
+++ b/tests/Integration/LoginSpec.elm
@@ -5,18 +5,17 @@ import Testable.TestContext exposing (..)
 import Testable.Html.Selectors exposing (..)
 import Expect exposing (equal)
 import Login.Update as Update
-import Login.Model as Model exposing (Model, loggedInUser)
+import Login.Model exposing (Model, loggedInUser, init)
 import Login.View.Login as View
 import Login.Msg exposing (Msg(..))
 import Login.Ports exposing (checkRegistration)
-import Login.Msg
 import Testable.Cmd
 
 
 loginContext : a -> TestContext Msg Model
 loginContext _ =
     startForTest
-        { init = ( Model.init Nothing, Testable.Cmd.none )
+        { init = ( init Nothing, Testable.Cmd.none )
         , update = (\msg model -> ( Update.update msg model, Update.cmdUpdate msg model ))
         , view = View.login
         }

--- a/tests/Integration/RidesSpec.elm
+++ b/tests/Integration/RidesSpec.elm
@@ -4,22 +4,23 @@ import Test exposing (..)
 import Testable.TestContext exposing (..)
 import Testable.Html.Selectors exposing (..)
 import Expect exposing (equal)
-import Update
-import Model
+import Rides.Update as Update
+import Rides.Model exposing (Model, Ride, init)
 import Rides.RoutesList exposing (routesList)
-import Msg
+import Rides.Msg exposing (Msg(..))
+import Testable.Cmd
 
 
-ridesContext : a -> TestContext Msg.Msg Model.Model
+ridesContext : a -> TestContext Msg Model
 ridesContext _ =
     startForTest
-        { init = Model.init { currentUser = Nothing }
-        , update = Update.update
+        { init = ( init, Testable.Cmd.none )
+        , update = (\msg model -> ( Update.update msg model, Testable.Cmd.none ))
         , view = routesList
         }
 
 
-ridesExample : List Model.Ride
+ridesExample : List Ride
 ridesExample =
     [ { id = "1", name = "foo", origin = "lorem", destination = "ipsum", area = "dolor", days = "sit", hours = "amet", flexible = True, formUrl = "http://foo" }
     , { id = "2", name = "bar", origin = "lorem", destination = "ipsum", area = "dolor", days = "sit", hours = "amet", flexible = True, formUrl = "http://foo" }
@@ -36,7 +37,7 @@ tests =
                 >> assertNodeCount (Expect.equal 0)
         , test "renders routes when they load" <|
             ridesContext
-                >> update (Msg.UpdateRides ridesExample)
+                >> update (UpdateRides ridesExample)
                 >> findAll [ class "ride-card" ]
                 >> assertNodeCount (Expect.equal 2)
         ]

--- a/tests/Integration/RidesSpec.elm
+++ b/tests/Integration/RidesSpec.elm
@@ -1,4 +1,4 @@
-module Integration.RoutesBoxSpec exposing (..)
+module Integration.RidesSpec exposing (..)
 
 import Test exposing (..)
 import Testable.TestContext exposing (..)
@@ -6,12 +6,12 @@ import Testable.Html.Selectors exposing (..)
 import Expect exposing (equal)
 import Update
 import Model
-import RoutesBox.RoutesList exposing (routesList)
+import Rides.RoutesList exposing (routesList)
 import Msg
 
 
-routesBoxContext : a -> TestContext Msg.Msg Model.Model
-routesBoxContext _ =
+RidesContext : a -> TestContext Msg.Msg Model.Model
+RidesContext _ =
     startForTest
         { init = Model.init { currentUser = Nothing }
         , update = Update.update
@@ -28,14 +28,14 @@ ridersExample =
 
 tests : Test
 tests =
-    describe "RoutesBox"
+    describe "Rides"
         [ test "renders no routes when there are no riders loaded yet" <|
-            routesBoxContext
+            RidesContext
                 >> find [ class "routes-box" ]
                 >> thenFindAll [ class "route" ]
                 >> assertNodeCount (Expect.equal 0)
         , test "renders routes when they load" <|
-            routesBoxContext
+            RidesContext
                 >> update (Msg.UpdateRiders ridersExample)
                 >> findAll [ class "rider-card" ]
                 >> assertNodeCount (Expect.equal 2)

--- a/tests/Integration/RidesSpec.elm
+++ b/tests/Integration/RidesSpec.elm
@@ -10,8 +10,8 @@ import Rides.RoutesList exposing (routesList)
 import Msg
 
 
-RidesContext : a -> TestContext Msg.Msg Model.Model
-RidesContext _ =
+ridesContext : a -> TestContext Msg.Msg Model.Model
+ridesContext _ =
     startForTest
         { init = Model.init { currentUser = Nothing }
         , update = Update.update
@@ -19,8 +19,8 @@ RidesContext _ =
         }
 
 
-ridersExample : List Model.Rider
-ridersExample =
+ridesExample : List Model.Ride
+ridesExample =
     [ { id = "1", name = "foo", origin = "lorem", destination = "ipsum", area = "dolor", days = "sit", hours = "amet", flexible = True, formUrl = "http://foo" }
     , { id = "2", name = "bar", origin = "lorem", destination = "ipsum", area = "dolor", days = "sit", hours = "amet", flexible = True, formUrl = "http://foo" }
     ]
@@ -29,14 +29,14 @@ ridersExample =
 tests : Test
 tests =
     describe "Rides"
-        [ test "renders no routes when there are no riders loaded yet" <|
-            RidesContext
+        [ test "renders no routes when there are no rides loaded yet" <|
+            ridesContext
                 >> find [ class "routes-box" ]
                 >> thenFindAll [ class "route" ]
                 >> assertNodeCount (Expect.equal 0)
         , test "renders routes when they load" <|
-            RidesContext
-                >> update (Msg.UpdateRiders ridersExample)
-                >> findAll [ class "rider-card" ]
+            ridesContext
+                >> update (Msg.UpdateRides ridesExample)
+                >> findAll [ class "ride-card" ]
                 >> assertNodeCount (Expect.equal 2)
         ]

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -4,7 +4,7 @@ import Test.Runner.Node exposing (run)
 import Json.Encode exposing (Value)
 import Test exposing (..)
 import Fuzz.ExampleSpec
-import Integration.RoutesBoxSpec
+import Integration.RidesSpec
 import Integration.LoginSpec
 import Integration.LayoutSpec
 
@@ -13,7 +13,7 @@ tests : Test
 tests =
     Test.concat
         [ Fuzz.ExampleSpec.tests
-        , Integration.RoutesBoxSpec.tests
+        , Integration.RidesSpec.tests
         , Integration.LoginSpec.tests
         , Integration.LayoutSpec.tests
         ]


### PR DESCRIPTION
This renames Riders to Rides, because:

Rider = passageiro
Ride = passeio, carona

Also, it moves rides logic outa of root, into rides module