### PR TITLE
Load splash screen can load as fast as possible

### DIFF
--- a/elm-static-html.json
+++ b/elm-static-html.json
@@ -1,7 +1,7 @@
 {
     "files": {
         "src/app/View.elm": {
-            "output": "build/elm.html",
+            "output": "build/splash.html",
             "viewFunction": "staticView"
         }
     }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/CaronaBoard/caronaboard#readme",
   "dependencies": {
+    "fg-loadcss": "^1.3.1",
     "firebase": "^3.5.3",
     "http-server": "^0.9.0"
   },

--- a/src/elm.js
+++ b/src/elm.js
@@ -1,0 +1,23 @@
+var app;
+var connectFirebase;
+
+System.import('./app/Main.elm').then(function (Elm) {
+  var currentUser = Object.keys(localStorage).filter(function (key) {
+    return key.match(/firebase:authUser/);
+  }).map(function (key) {
+    return JSON.parse(localStorage.getItem(key));
+  }).map(function (user) {
+    return { id: user.uid, name: user.displayName || ""}
+  })[0] || null;
+
+  app = Elm.Main.embed(document.getElementById('page-wrap'), { currentUser: currentUser });
+  if (connectFirebase) connectFirebase(app);
+
+  // Load dropdown fix for materialize
+  require('./dropdown');
+});
+
+System.import('./firebase').then(function (connect) {
+  connectFirebase = connect;
+  if (app) connectFirebase(app);
+});

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -22,10 +22,11 @@
     <link rel="stylesheet" href="<%= require('./css/splash.scss') %>">
     <div id="page-wrap"><%= require('../build/elm.html') %></div>
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.0/css/materialize.min.css">
-    <link rel="stylesheet" href="<%= require('./css/main.scss') %>">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
+    <% deferCss = 'media="none" onload="if(media!=\'all\')media=\'all\'"' %>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.0/css/materialize.min.css" <%= deferCss %>>
+    <link rel="stylesheet" href="<%= require('./css/main.scss') %>" <%= deferCss %>>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
 
     <script>
       if ('serviceWorker' in navigator) {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -19,23 +19,12 @@
     <meta name="theme-color" content="#0255FB">
   </head>
   <body>
-    <link rel="stylesheet" href="<%= require('./css/splash.scss') %>">
-    <div id="page-wrap"><%= require('../build/elm.html') %></div>
+    <style>
+      <%= require('raw-loader!./css/splash.scss') %>
+    </style>
+    <div id="page-wrap"><%= require('../build/splash.html') %></div>
 
-    <% deferCss = 'media="none" onload="if(media!=\'all\')media=\'all\'"' %>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.0/css/materialize.min.css" <%= deferCss %>>
-    <link rel="stylesheet" href="<%= require('./css/main.scss') %>" <%= deferCss %>>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700">
-
-    <script>
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', function() {
-          navigator.serviceWorker.register('/service-worker.js');
-        });
-      }
-    </script>
-    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.0/js/materialize.min.js"></script>
+    <script async src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script async src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.0/js/materialize.min.js"></script>
   </body>
 <html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,17 @@
-var Elm = require('./app/Main.elm');
+// After splash screen loaded
+window.addEventListener('load', function () {
+  // Load all CSS
+  var loadCSS = require('fg-loadcss').loadCSS;
+  loadCSS('https://cdnjs.cloudflare.com/ajax/libs/materialize/0.98.0/css/materialize.min.css');
+  loadCSS(require('file-loader?name=[name].[hash].css!./css/main.scss'));
+  loadCSS('https://fonts.googleapis.com/icon?family=Material+Icons');
+  loadCSS('https://fonts.googleapis.com/css?family=Lato:400,700');
 
-var currentUser = Object.keys(localStorage).filter(function (key) {
-  return key.match(/firebase:authUser/);
-}).map(function (key) {
-  return JSON.parse(localStorage.getItem(key));
-}).map(function (user) {
-  return { id: user.uid, name: user.displayName || ""}
-})[0] || null;
+  // Load Elm and connect it with Firebase
+  require('./elm.js');
 
-var app = Elm.Main.embed(document.getElementById('page-wrap'), { currentUser: currentUser });
-
-System.import('./firebase').then(function (connectFirebase) {
-  connectFirebase(app);
+  // Load serviceWorkers
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/service-worker.js');
+  }
 });
-
-require('./dropdown');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ const config = {
     loaders: [
       {
         test: /\.s?css$/,
-        loaders: ['file-loader?name=[name].[hash].css', 'sass-loader']
+        loaders: ['sass-loader']
       },
       {
         test: /\.elm$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -824,13 +824,13 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2.2.0, debug@^2.2.0, debug@~2.2.0:
+debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
 
-debug@2.3.3:
+debug@2.3.3, debug@^2.2.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
   dependencies:
@@ -1319,6 +1319,10 @@ fd-slicer@~1.0.1:
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
   dependencies:
     pend "~1.2.0"
+
+fg-loadcss@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/fg-loadcss/-/fg-loadcss-1.3.1.tgz#8930e820959faafbb242850eeec4f2d0259430cb"
 
 file-loader@^0.10.0:
   version "0.10.0"
@@ -2415,11 +2419,11 @@ moment@2.x.x:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
 
-ms@0.7.1, ms@^0.7.1:
+ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
-ms@0.7.2:
+ms@0.7.2, ms@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 


### PR DESCRIPTION
So, I decided to play a little to see how can we load the app as fast as possible. And I decided to give the [Above the Fold CSS Optimization](https://css-tricks.com/authoring-critical-fold-css/) a try.

On Chrome, by simulating a 2G connection on a low-end device (5x CPU slowdown), I've managed to make the splash screen load at impressive 800ms.

![image](https://cloud.githubusercontent.com/assets/792201/23099005/31ce1f9e-f63b-11e6-8f36-6856ff246494.png)

I've also tested a lot on my own device, an iPhone 6 using Vivo EDGE (2G) network with safari private mode, by deploying to now.sh. It takes about ~4 seconds to load the splash screen, with the first ~3 apparently being the HTTPs handshake (so the chrome simulations make sense). It takes 15s more to fully load the app.

On Vivo 3G, the handshake seems to take the same ~3s, with the splash screen on ~4s and the app fully loaded at ~6s.

On 4G it loads in ~4s.

In any case the second load takes about 2s.

It does add some complexity to the code, if we think it is not worth it, we can remove it later.