### PR TITLE
Add button to forgot my password

### DIFF
--- a/src/app/Common/Form.elm
+++ b/src/app/Common/Form.elm
@@ -1,20 +1,20 @@
 module Common.Form exposing (loadingOrSubmitButton, renderErrors)
 
-import Testable.Html exposing (Html, div, button, text, i)
+import Testable.Html exposing (Html, Attribute, div, button, text, i)
 import Testable.Html.Attributes exposing (id, value, disabled, class)
 import Login.Msg exposing (Msg(..))
 import Common.Response exposing (Response(..))
 
 
-loadingOrSubmitButton : List (Html Msg) -> Response a -> Html Msg
-loadingOrSubmitButton buttonChildren response =
+loadingOrSubmitButton : Response a -> List (Attribute Msg) -> List (Html Msg) -> Html Msg
+loadingOrSubmitButton response extraAttributes children =
     case response of
         Loading ->
-            button [ disabled True, class "waves-effect waves-light btn-large" ]
+            button ([ disabled True, class "waves-effect waves-light btn-large" ] ++ extraAttributes)
                 [ i [] [], text "Carregando..." ]
 
         _ ->
-            button [ class "waves-effect waves-light btn-large" ] buttonChildren
+            button ([ class "waves-effect waves-light btn-large" ] ++ extraAttributes) children
 
 
 renderErrors : Response a -> Html Msg

--- a/src/app/Login/Model.elm
+++ b/src/app/Login/Model.elm
@@ -8,6 +8,7 @@ type alias Model =
     , password : String
     , registered : Response Bool
     , loggedIn : Response User
+    , passwordReset : Response ()
     }
 
 
@@ -63,4 +64,5 @@ init user =
         user
             |> Maybe.map Success
             |> Maybe.withDefault Empty
+    , passwordReset = Empty
     }

--- a/src/app/Login/Msg.elm
+++ b/src/app/Login/Msg.elm
@@ -11,6 +11,8 @@ type Msg
     | SignInResponse ( Maybe Error, Maybe User )
     | SignOut
     | SignOutResponse
+    | PasswordReset
+    | PasswordResetResponse (Maybe Error)
 
 
 type alias Error =

--- a/src/app/Login/Ports.elm
+++ b/src/app/Login/Ports.elm
@@ -1,7 +1,7 @@
-port module Login.Ports exposing (subscriptions, checkRegistration, signIn, signOut)
+port module Login.Ports exposing (subscriptions, checkRegistration, signIn, signOut, passwordReset, passwordResetResponse)
 
 import Login.Model exposing (User)
-import Login.Msg exposing (Msg(..))
+import Login.Msg exposing (Msg(CheckRegistrationResponse, SignInResponse, SignOutResponse, PasswordResetResponse))
 
 
 subscriptions : Sub Msg
@@ -10,6 +10,7 @@ subscriptions =
         [ checkRegistrationResponse CheckRegistrationResponse
         , signInResponse SignInResponse
         , signOutResponse (always SignOutResponse)
+        , passwordResetResponse PasswordResetResponse
         ]
 
 
@@ -45,3 +46,13 @@ port signOut : () -> Cmd msg
 
 
 port signOutResponse : (() -> msg) -> Sub msg
+
+
+
+-- passwordReset
+
+
+port passwordReset : String -> Cmd msg
+
+
+port passwordResetResponse : (Maybe Error -> msg) -> Sub msg

--- a/src/app/Login/Update.elm
+++ b/src/app/Login/Update.elm
@@ -2,7 +2,7 @@ module Login.Update exposing (update)
 
 import Msg as Root exposing (Msg(MsgForUrlRouter, MsgForLogin))
 import Login.Model exposing (Model, Step(..), User, step, init)
-import Login.Ports exposing (checkRegistration, signIn, signOut)
+import Login.Ports exposing (checkRegistration, signIn, signOut, passwordReset)
 import Login.Msg exposing (Msg(..))
 import Testable.Cmd
 import Common.Response exposing (Response(..))
@@ -60,3 +60,14 @@ loginUpdate msg model =
 
         SignOutResponse ->
             ( init Nothing, Testable.Cmd.none )
+
+        PasswordReset ->
+            ( { model | passwordReset = Loading }, Testable.Cmd.wrap <| passwordReset model.email )
+
+        PasswordResetResponse error ->
+            let
+                response =
+                    Maybe.map Error error
+                        |> Maybe.withDefault (Success ())
+            in
+                ( { model | passwordReset = response }, Testable.Cmd.none )

--- a/src/app/Login/View/EmailStep.elm
+++ b/src/app/Login/View/EmailStep.elm
@@ -23,9 +23,5 @@ emailStep model =
                 []
             , label [ for "email" ] [ text "Email" ]
             ]
-        , loadingOrSubmitButton
-            [ iconRight "forward"
-            , text "Próximo"
-            ]
-            model.registered
+        , loadingOrSubmitButton model.registered [] [ iconRight "forward", text "Próximo" ]
         ]

--- a/src/app/Login/View/Login.elm
+++ b/src/app/Login/View/Login.elm
@@ -1,7 +1,6 @@
 module Login.View.Login exposing (login)
 
 import Testable.Html exposing (Html, div, h2, input, text, form)
-import Testable.Html.Attributes exposing (id, type_, placeholder, value, class, disabled)
 import Testable.Html.Events exposing (onInput, onSubmit)
 import Login.Msg exposing (Msg(..))
 import Login.Model exposing (Model, Step(..), step)
@@ -11,12 +10,6 @@ import Login.View.PasswordStep exposing (passwordStep)
 
 login : Model -> Html Msg
 login model =
-    div [ id "login", class "col s12 m8 offset-m2 l6 offset-l3" ]
-        [ stepForm model ]
-
-
-stepForm : Model -> Html Msg
-stepForm model =
     case step model of
         EmailStep ->
             formStep (emailStep model)

--- a/src/app/Login/View/PasswordReset.elm
+++ b/src/app/Login/View/PasswordReset.elm
@@ -1,0 +1,8 @@
+module Login.View.PasswordReset exposing (passwordReset)
+
+import Testable.Html exposing (Html, text)
+
+
+passwordReset : Html a
+passwordReset =
+    text "Email de recuperação de senha enviado, veja sua caixa de entrada"

--- a/src/app/Login/View/PasswordStep.elm
+++ b/src/app/Login/View/PasswordStep.elm
@@ -2,17 +2,19 @@ module Login.View.PasswordStep exposing (passwordStep)
 
 import Testable.Html exposing (Html, div, input, text, i, label)
 import Testable.Html.Attributes exposing (class, id, type_, for, placeholder, value, autofocus)
-import Testable.Html.Events exposing (onInput, onSubmit)
-import Login.Msg exposing (Msg(..))
+import Testable.Html.Events exposing (onInput, onSubmit, onWithOptions)
+import Login.Msg exposing (Msg(UpdatePassword, PasswordReset))
 import Login.Model exposing (Model)
 import Common.Form exposing (loadingOrSubmitButton, renderErrors)
 import Common.Icon exposing (iconRight)
+import Json.Decode as Json
 
 
 passwordStep : Model -> Html Msg
 passwordStep model =
     div [ class "password-step" ]
         [ renderErrors model.loggedIn
+        , renderErrors model.passwordReset
         , text model.email
         , div [ class "input-field" ]
             [ input
@@ -25,9 +27,11 @@ passwordStep model =
                 []
             , label [ for "password" ] [ text "Senha" ]
             ]
-        , loadingOrSubmitButton
-            [ iconRight "done"
-            , text "Entrar"
+        , loadingOrSubmitButton model.loggedIn [] [ iconRight "done", text "Entrar" ]
+        , loadingOrSubmitButton model.passwordReset
+            [ class "btn-flat"
+            , id "password-reset-button"
+            , onWithOptions "click" { stopPropagation = True, preventDefault = True } (Json.succeed PasswordReset)
             ]
-            model.loggedIn
+            [ text "Esqueci a Senha" ]
         ]

--- a/src/app/UrlRouter/Routes.elm
+++ b/src/app/UrlRouter/Routes.elm
@@ -10,6 +10,7 @@ type Page
     | LoginPage
     | RidesPage
     | NotFoundPage
+    | PasswordResetPage
 
 
 pageParser : Parser (Page -> a) a
@@ -18,6 +19,7 @@ pageParser =
         [ map SplashScreenPage (static "")
         , map LoginPage (static "login")
         , map RidesPage (static "rides")
+        , map PasswordResetPage (static "password-reset")
         ]
 
 
@@ -35,6 +37,9 @@ toPath page =
 
         NotFoundPage ->
             "#/not-found"
+
+        PasswordResetPage ->
+            "#/password-reset"
 
 
 redirectTo : Login.Model -> Page -> Page
@@ -60,6 +65,9 @@ redirectTo login page =
 
         NotFoundPage ->
             NotFoundPage
+
+        PasswordResetPage ->
+            PasswordResetPage
 
 
 pathParser : Navigation.Location -> Maybe Page

--- a/src/app/UrlRouter/Update.elm
+++ b/src/app/UrlRouter/Update.elm
@@ -3,11 +3,11 @@ module UrlRouter.Update exposing (update, urlRouterUpdate, changePageTo)
 import Login.Model as Login
 import UrlRouter.Model exposing (Model)
 import UrlRouter.Msg exposing (Msg(Go, UrlChange))
-import UrlRouter.Routes exposing (Page(NotFoundPage, RidesPage, LoginPage), pathParser, toPath, redirectTo)
+import UrlRouter.Routes exposing (Page(NotFoundPage, RidesPage, LoginPage, PasswordResetPage), pathParser, toPath, redirectTo)
 import Testable.Cmd
 import Navigation exposing (Location)
 import Msg as Root exposing (Msg(MsgForUrlRouter, MsgForLogin))
-import Login.Msg exposing (Msg(SignInResponse, SignOutResponse))
+import Login.Msg exposing (Msg(SignInResponse, SignOutResponse, PasswordResetResponse))
 
 
 update : Root.Msg -> Model -> Login.Model -> ( Model, Testable.Cmd.Cmd UrlRouter.Msg.Msg )
@@ -21,6 +21,9 @@ update msg model login =
 
         MsgForLogin SignOutResponse ->
             urlRouterUpdate (Go LoginPage) model login
+
+        MsgForLogin (PasswordResetResponse Nothing) ->
+            urlRouterUpdate (Go PasswordResetPage) model login
 
         _ ->
             ( model, Testable.Cmd.none )

--- a/src/app/View.elm
+++ b/src/app/View.elm
@@ -7,8 +7,9 @@ import Html
 import Model exposing (Model, init)
 import Msg exposing (Msg(MsgForLogin))
 import Layout.SplashScreen exposing (splashScreen)
-import UrlRouter.Routes exposing (Page(SplashScreenPage, LoginPage, RidesPage, NotFoundPage))
+import UrlRouter.Routes exposing (Page(SplashScreenPage, LoginPage, RidesPage, NotFoundPage, PasswordResetPage))
 import Login.View.Login exposing (login)
+import Login.View.PasswordReset exposing (passwordReset)
 import Layout.Header exposing (header)
 import Rides.View.Instructions exposing (instructions)
 import Rides.View.RoutesList exposing (routesList)
@@ -32,10 +33,7 @@ routeRender model =
             splashScreen
 
         LoginPage ->
-            div [ id "login-page" ]
-                [ div [ class "row" ]
-                    [ Testable.Html.map MsgForLogin <| login model.login ]
-                ]
+            loginLayout (Testable.Html.map MsgForLogin <| login model.login)
 
         RidesPage ->
             div [ id "rides-page" ]
@@ -46,3 +44,16 @@ routeRender model =
 
         NotFoundPage ->
             h1 [] [ text "404 não encontrado" ]
+
+        PasswordResetPage ->
+            loginLayout passwordReset
+
+
+loginLayout : Testable.Html.Html Msg -> Testable.Html.Html Msg
+loginLayout child =
+    div [ id "login-page" ]
+        [ div [ class "row" ]
+            [ div [ id "login", class "col s12 m8 offset-m2 l6 offset-l3" ]
+                [ child ]
+            ]
+        ]

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -66,4 +66,12 @@ module.exports = function (app) {
       signOutUser();
     }
   });
+
+  app.ports.passwordReset.subscribe(function (email) {
+    firebase.auth().sendPasswordResetEmail(email).then(function () {
+      app.ports.passwordResetResponse.send(null);
+    }).catch(function (error) {
+      app.ports.passwordResetResponse.send(error.message);
+    });
+  });
 }


### PR DESCRIPTION
This is an alternative solution for #30, instead of providing a default password to the beta users and force then to change it later, we can simply *not* provide them a password, and let them use the forgot my password functionality.

This is both faster to implement (as I just did) and safer as one person will not be able to login as the other with the default password.

So, after you type the email on the first step, I've added a forgot my password button. Any UI improvements suggestion @thiagorocha23? (edit: actually, right now, login page is totally different from what you suggested, we still need to work on that)
![image](https://cloud.githubusercontent.com/assets/792201/23143871/91649880-f7a2-11e6-83d6-ed7fd04aa58c.png)

Then firebase sends an email to you
![image](https://cloud.githubusercontent.com/assets/792201/23143872/98638ab0-f7a2-11e6-9c9b-cd8f5e13b89f.png)
![image](https://cloud.githubusercontent.com/assets/792201/23143928/02222268-f7a3-11e6-8634-7dc92181d574.png)

The link opens up this screen for you to create a new password:

![image](https://cloud.githubusercontent.com/assets/792201/23143967/3dc2df42-f7a3-11e6-814c-97973171ee6a.png)

We probably can customize the email message and maybe the change password screen, but idk how, maybe @jcmidia knows more about that

With this change we will already be able to launch caronaboard for the beta users and get their feedback to move forward.
What do you think @luismizutani?
