### PR TITLE
Adds cursor pointer for a tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 elm-stuff/
 .elm-static-html
 id_rsa_caronaboard
+.idea/

--- a/src/app/Layout/Styles.elm
+++ b/src/app/Layout/Styles.elm
@@ -77,6 +77,7 @@ generalStyles =
     , a
         [ textDecoration none
         , linkColor
+        , cursor pointer
         ]
     , h1
         [ fontWeight normal


### PR DESCRIPTION
This PR adds css `cursor:pointer` for all  `a` elements.
This will fix some usability problems.

Adds `.idea/` folder to `.gitignore` also.