### PR TITLE
Add request to join group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2156,7 +2156,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "4.0.0",
-          "resolved": "https://packages.it.lan.com:443/artifactory/api/npm/lnpm/cross-spawn/-/cross-spawn-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.0.tgz",
           "integrity": "sha1-glR3SrR4a4xbPPTfumbOVjkywlI=",
           "dev": true,
           "requires": {
@@ -2172,7 +2172,7 @@
         },
         "fs-extra": {
           "version": "0.30.0",
-          "resolved": "https://packages.it.lan.com:443/artifactory/api/npm/lnpm/fs-extra/-/fs-extra-0.30.0.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
@@ -2199,7 +2199,7 @@
         },
         "lodash": {
           "version": "4.13.1",
-          "resolved": "https://packages.it.lan.com:443/artifactory/api/npm/lnpm/lodash/-/lodash-4.13.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
           "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g=",
           "dev": true
         }

--- a/src/app/Common/Colors.elm
+++ b/src/app/Common/Colors.elm
@@ -28,6 +28,11 @@ lighterBlue =
     rgb 80 130 255
 
 
+darkerBlue : Color
+darkerBlue =
+    rgb 0 50 200
+
+
 primaryBlack : Color
 primaryBlack =
     rgb 85 85 85

--- a/src/app/Groups/Model.elm
+++ b/src/app/Groups/Model.elm
@@ -1,4 +1,4 @@
-module Groups.Model exposing (Group, Model, Msg(..), isMemberOfGroup)
+module Groups.Model exposing (Group, Member, Model, Msg(..), isMemberOfGroup)
 
 import Common.Response exposing (Response)
 import Login.Model exposing (signedInUser)
@@ -12,9 +12,13 @@ type alias Model =
 type alias Group =
     { id : String
     , name : String
-    , users : List Id
+    , members : List Member
     , joinRequest : Response Bool
     }
+
+
+type alias Member =
+    { userId : Id, admin : Bool }
 
 
 type alias Id =
@@ -29,6 +33,10 @@ type Msg
 
 isMemberOfGroup : Login.Model.Model -> Group -> Bool
 isMemberOfGroup login group =
+    let
+        memberIds =
+            List.map .userId group.members
+    in
     signedInUser login
-        |> Maybe.map (\user -> List.member user.id group.users)
+        |> Maybe.map (\user -> List.member user.id memberIds)
         |> Maybe.withDefault False

--- a/src/app/Groups/Model.elm
+++ b/src/app/Groups/Model.elm
@@ -1,6 +1,7 @@
-module Groups.Model exposing (Group, Model, Msg(..))
+module Groups.Model exposing (Group, Model, Msg(..), isMemberOfGroup)
 
 import Common.Response exposing (Response)
+import Login.Model exposing (signedInUser)
 
 
 type alias Model =
@@ -11,8 +12,20 @@ type alias Model =
 type alias Group =
     { id : String
     , name : String
+    , users : List Id
     }
+
+
+type alias Id =
+    String
 
 
 type Msg
     = UpdateGroups (Response (List Group))
+
+
+isMemberOfGroup : Login.Model.Model -> Group -> Bool
+isMemberOfGroup login group =
+    signedInUser login
+        |> Maybe.map (\user -> List.member user.id group.users)
+        |> Maybe.withDefault False

--- a/src/app/Groups/Model.elm
+++ b/src/app/Groups/Model.elm
@@ -13,6 +13,7 @@ type alias Group =
     { id : String
     , name : String
     , users : List Id
+    , joinRequest : Response Bool
     }
 
 
@@ -22,6 +23,8 @@ type alias Id =
 
 type Msg
     = UpdateGroups (Response (List Group))
+    | CreateJoinGroupRequest Id
+    | CreateJoinGroupRequestResponse Id (Response Bool)
 
 
 isMemberOfGroup : Login.Model.Model -> Group -> Bool

--- a/src/app/Groups/Model.elm
+++ b/src/app/Groups/Model.elm
@@ -15,7 +15,7 @@ type alias Group =
     , name : String
     , members : List Member
     , joinRequest : Response Bool
-    , joinRequests : List JoinRequest
+    , joinRequests : Response (List JoinRequest)
     }
 
 
@@ -39,6 +39,7 @@ type Msg
     = UpdateGroups (Response (List Group))
     | CreateJoinGroupRequest GroupId
     | CreateJoinGroupRequestResponse GroupId (Response Bool)
+    | JoinRequestsListResponse GroupId (Response (List JoinRequest))
     | RespondJoinRequest GroupId UserId Bool
     | RespondJoinRequestResponse GroupId UserId (Response Bool)
 
@@ -56,19 +57,24 @@ isMemberOfGroup login group =
 
 pendingJoinRequests : Group -> List JoinRequest
 pendingJoinRequests group =
-    group.joinRequests
-        |> List.filter
-            (\joinRequest ->
-                case joinRequest.response of
-                    Empty ->
-                        True
+    case group.joinRequests of
+        Success joinRequests ->
+            List.filter
+                (\joinRequest ->
+                    case joinRequest.response of
+                        Empty ->
+                            True
 
-                    Error _ ->
-                        True
+                        Error _ ->
+                            True
 
-                    Success _ ->
-                        False
+                        Success _ ->
+                            False
 
-                    Loading ->
-                        False
-            )
+                        Loading ->
+                            False
+                )
+                joinRequests
+
+        _ ->
+            []

--- a/src/app/Groups/Model.elm
+++ b/src/app/Groups/Model.elm
@@ -39,8 +39,8 @@ type Msg
     = UpdateGroups (Response (List Group))
     | CreateJoinGroupRequest GroupId
     | CreateJoinGroupRequestResponse GroupId (Response Bool)
-    | AcceptJoinRequest GroupId UserId
-    | AcceptJoinRequestResponse GroupId UserId (Response Bool)
+    | RespondJoinRequest GroupId UserId Bool
+    | RespondJoinRequestResponse GroupId UserId (Response Bool)
 
 
 isMemberOfGroup : Login.Model.Model -> Group -> Bool

--- a/src/app/Groups/Model.elm
+++ b/src/app/Groups/Model.elm
@@ -1,7 +1,8 @@
-module Groups.Model exposing (Group, Member, Model, Msg(..), isMemberOfGroup)
+module Groups.Model exposing (Group, JoinRequest, Member, Model, Msg(..), isMemberOfGroup)
 
 import Common.Response exposing (Response)
 import Login.Model exposing (signedInUser)
+import Profile.Model exposing (Profile)
 
 
 type alias Model =
@@ -14,11 +15,16 @@ type alias Group =
     , name : String
     , members : List Member
     , joinRequest : Response Bool
+    , joinRequests : List JoinRequest
     }
 
 
 type alias Member =
     { userId : Id, admin : Bool }
+
+
+type alias JoinRequest =
+    { userId : Id, profile : Profile }
 
 
 type alias Id =

--- a/src/app/Groups/Ports.elm
+++ b/src/app/Groups/Ports.elm
@@ -25,6 +25,7 @@ decodeGroup =
     decode Group
         |> hardcoded "id"
         |> required "name" string
+        |> required "users" (list string)
 
 
 port groupsList : () -> Cmd msg

--- a/src/app/Groups/Ports.elm
+++ b/src/app/Groups/Ports.elm
@@ -4,12 +4,14 @@ port module Groups.Ports
         , createJoinGroupRequestResponse
         , groupsList
         , groupsListResponse
+        , joinRequestsList
+        , joinRequestsListResponse
         , respondJoinRequest
         , respondJoinRequestResponse
         , subscriptions
         )
 
-import Common.Decoder exposing (normalizeId)
+import Common.Decoder exposing (normalizeId, normalizeId2)
 import Common.Response exposing (FirebaseResponse, Response(..), decodeFromFirebase)
 import Groups.Model exposing (Group, JoinRequest, Member, Model, Msg(..))
 import Json.Decode as Json exposing (..)
@@ -29,6 +31,10 @@ subscriptions =
             (\response ->
                 RespondJoinRequestResponse response.groupId response.userId (decodeFromFirebase bool response.response)
             )
+        , joinRequestsListResponse
+            (\response ->
+                JoinRequestsListResponse response.groupId (decodeFromFirebase decodeJoinRequests response.response)
+            )
         ]
 
 
@@ -46,7 +52,8 @@ decodeGroup =
         |> optional "members" decodeMembers []
         -- joinRequest
         |> hardcoded Empty
-        |> optional "joinRequests" decodeJoinRequests []
+        -- joinRequests
+        |> hardcoded Empty
 
 
 decodeMembers : Decoder (List Member)
@@ -83,3 +90,9 @@ port respondJoinRequest : { groupId : String, userId : String, accepted : Bool }
 
 
 port respondJoinRequestResponse : ({ groupId : String, userId : String, response : FirebaseResponse Json.Value } -> msg) -> Sub msg
+
+
+port joinRequestsList : { groupId : String } -> Cmd msg
+
+
+port joinRequestsListResponse : ({ groupId : String, response : FirebaseResponse Json.Value } -> msg) -> Sub msg

--- a/src/app/Groups/Ports.elm
+++ b/src/app/Groups/Ports.elm
@@ -1,7 +1,7 @@
-port module Groups.Ports exposing (groupsList, groupsListResponse, subscriptions)
+port module Groups.Ports exposing (createJoinGroupRequest, createJoinGroupRequestResponse, groupsList, groupsListResponse, subscriptions)
 
 import Common.Decoder exposing (normalizeId)
-import Common.Response exposing (FirebaseResponse, decodeFromFirebase)
+import Common.Response exposing (FirebaseResponse, Response(..), decodeFromFirebase)
 import Groups.Model exposing (Group, Model, Msg(..))
 import Json.Decode as Json exposing (..)
 import Json.Decode.Pipeline exposing (..)
@@ -11,6 +11,10 @@ subscriptions : Sub Msg
 subscriptions =
     Sub.batch
         [ groupsListResponse (decodeFromFirebase decodeGroups >> UpdateGroups)
+        , createJoinGroupRequestResponse
+            (\response ->
+                CreateJoinGroupRequestResponse response.groupId (decodeFromFirebase bool response.response)
+            )
         ]
 
 
@@ -26,9 +30,17 @@ decodeGroup =
         |> hardcoded "id"
         |> required "name" string
         |> required "users" (list string)
+        -- joinRequest
+        |> hardcoded Empty
 
 
 port groupsList : () -> Cmd msg
 
 
 port groupsListResponse : (FirebaseResponse Json.Value -> msg) -> Sub msg
+
+
+port createJoinGroupRequest : { groupId : String } -> Cmd msg
+
+
+port createJoinGroupRequestResponse : ({ groupId : String, response : FirebaseResponse Json.Value } -> msg) -> Sub msg

--- a/src/app/Groups/Ports.elm
+++ b/src/app/Groups/Ports.elm
@@ -2,7 +2,7 @@ port module Groups.Ports exposing (createJoinGroupRequest, createJoinGroupReques
 
 import Common.Decoder exposing (normalizeId)
 import Common.Response exposing (FirebaseResponse, Response(..), decodeFromFirebase)
-import Groups.Model exposing (Group, Model, Msg(..))
+import Groups.Model exposing (Group, Member, Model, Msg(..))
 import Json.Decode as Json exposing (..)
 import Json.Decode.Pipeline exposing (..)
 
@@ -29,9 +29,17 @@ decodeGroup =
     decode Group
         |> hardcoded "id"
         |> required "name" string
-        |> required "users" (list string)
+        |> required "members" decodeMembers
         -- joinRequest
         |> hardcoded Empty
+
+
+decodeMembers : Decoder (List Member)
+decodeMembers =
+    decode Member
+        |> hardcoded "userId"
+        |> required "admin" bool
+        |> normalizeId (\userId member -> { member | userId = userId })
 
 
 port groupsList : () -> Cmd msg

--- a/src/app/Groups/Ports.elm
+++ b/src/app/Groups/Ports.elm
@@ -1,4 +1,13 @@
-port module Groups.Ports exposing (createJoinGroupRequest, createJoinGroupRequestResponse, groupsList, groupsListResponse, subscriptions)
+port module Groups.Ports
+    exposing
+        ( acceptJoinRequest
+        , acceptJoinRequestResponse
+        , createJoinGroupRequest
+        , createJoinGroupRequestResponse
+        , groupsList
+        , groupsListResponse
+        , subscriptions
+        )
 
 import Common.Decoder exposing (normalizeId)
 import Common.Response exposing (FirebaseResponse, Response(..), decodeFromFirebase)
@@ -15,6 +24,10 @@ subscriptions =
         , createJoinGroupRequestResponse
             (\response ->
                 CreateJoinGroupRequestResponse response.groupId (decodeFromFirebase bool response.response)
+            )
+        , acceptJoinRequestResponse
+            (\response ->
+                AcceptJoinRequestResponse response.groupId response.userId (decodeFromFirebase bool response.response)
             )
         ]
 
@@ -49,6 +62,8 @@ decodeJoinRequests =
     decode JoinRequest
         |> hardcoded "userId"
         |> required "profile" decodeProfile
+        -- response
+        |> hardcoded Empty
         |> normalizeId (\userId joinRequest -> { joinRequest | userId = userId })
 
 
@@ -62,3 +77,9 @@ port createJoinGroupRequest : { groupId : String } -> Cmd msg
 
 
 port createJoinGroupRequestResponse : ({ groupId : String, response : FirebaseResponse Json.Value } -> msg) -> Sub msg
+
+
+port acceptJoinRequest : { groupId : String, userId : String } -> Cmd msg
+
+
+port acceptJoinRequestResponse : ({ groupId : String, userId : String, response : FirebaseResponse Json.Value } -> msg) -> Sub msg

--- a/src/app/Groups/Ports.elm
+++ b/src/app/Groups/Ports.elm
@@ -2,9 +2,10 @@ port module Groups.Ports exposing (createJoinGroupRequest, createJoinGroupReques
 
 import Common.Decoder exposing (normalizeId)
 import Common.Response exposing (FirebaseResponse, Response(..), decodeFromFirebase)
-import Groups.Model exposing (Group, Member, Model, Msg(..))
+import Groups.Model exposing (Group, JoinRequest, Member, Model, Msg(..))
 import Json.Decode as Json exposing (..)
 import Json.Decode.Pipeline exposing (..)
+import Profile.Ports exposing (decodeProfile)
 
 
 subscriptions : Sub Msg
@@ -29,9 +30,10 @@ decodeGroup =
     decode Group
         |> hardcoded "id"
         |> required "name" string
-        |> required "members" decodeMembers
+        |> optional "members" decodeMembers []
         -- joinRequest
         |> hardcoded Empty
+        |> optional "joinRequests" decodeJoinRequests []
 
 
 decodeMembers : Decoder (List Member)
@@ -40,6 +42,14 @@ decodeMembers =
         |> hardcoded "userId"
         |> required "admin" bool
         |> normalizeId (\userId member -> { member | userId = userId })
+
+
+decodeJoinRequests : Decoder (List JoinRequest)
+decodeJoinRequests =
+    decode JoinRequest
+        |> hardcoded "userId"
+        |> required "profile" decodeProfile
+        |> normalizeId (\userId joinRequest -> { joinRequest | userId = userId })
 
 
 port groupsList : () -> Cmd msg

--- a/src/app/Groups/Ports.elm
+++ b/src/app/Groups/Ports.elm
@@ -1,11 +1,11 @@
 port module Groups.Ports
     exposing
-        ( acceptJoinRequest
-        , acceptJoinRequestResponse
-        , createJoinGroupRequest
+        ( createJoinGroupRequest
         , createJoinGroupRequestResponse
         , groupsList
         , groupsListResponse
+        , respondJoinRequest
+        , respondJoinRequestResponse
         , subscriptions
         )
 
@@ -25,9 +25,9 @@ subscriptions =
             (\response ->
                 CreateJoinGroupRequestResponse response.groupId (decodeFromFirebase bool response.response)
             )
-        , acceptJoinRequestResponse
+        , respondJoinRequestResponse
             (\response ->
-                AcceptJoinRequestResponse response.groupId response.userId (decodeFromFirebase bool response.response)
+                RespondJoinRequestResponse response.groupId response.userId (decodeFromFirebase bool response.response)
             )
         ]
 
@@ -79,7 +79,7 @@ port createJoinGroupRequest : { groupId : String } -> Cmd msg
 port createJoinGroupRequestResponse : ({ groupId : String, response : FirebaseResponse Json.Value } -> msg) -> Sub msg
 
 
-port acceptJoinRequest : { groupId : String, userId : String } -> Cmd msg
+port respondJoinRequest : { groupId : String, userId : String, accepted : Bool } -> Cmd msg
 
 
-port acceptJoinRequestResponse : ({ groupId : String, userId : String, response : FirebaseResponse Json.Value } -> msg) -> Sub msg
+port respondJoinRequestResponse : ({ groupId : String, userId : String, response : FirebaseResponse Json.Value } -> msg) -> Sub msg

--- a/src/app/Groups/Styles.elm
+++ b/src/app/Groups/Styles.elm
@@ -24,6 +24,7 @@ type Classes
     | List
     | JoinRequests
     | JoinRequest
+    | RespondButton
 
 
 styles : Stylesheet
@@ -61,9 +62,20 @@ styles =
             [ marginBottom (px 30)
             ]
         , class JoinRequest <|
-            [ padding (px 5)
-            , backgroundColor primaryBlue
+            [ backgroundColor primaryBlue
             , lightTextColor
             , marginBottom (px 8)
+            , displayFlex
+            , alignItems center
+            , justifyContent spaceBetween
+            , padding2 (px 0) (px 10)
+            ]
+        , class RespondButton <|
+            [ lightTextColor
+            , padding4 (px 5) (px 15) (px 2) (px 15)
+            , fontSize (px 18)
+            , backgroundColor darkerBlue
+            , borderStyle none
+            , marginRight (px 5)
             ]
         ]

--- a/src/app/Groups/Styles.elm
+++ b/src/app/Groups/Styles.elm
@@ -6,7 +6,7 @@ import Css exposing (..)
 import Css.Elements exposing (..)
 import Css.Namespace
 import Html exposing (Attribute)
-import Layout.Styles exposing (container)
+import Layout.Styles exposing (card, container)
 
 
 namespace : String
@@ -22,6 +22,8 @@ className =
 type Classes
     = ListContainer
     | List
+    | JoinRequests
+    | JoinRequest
 
 
 styles : Stylesheet
@@ -54,5 +56,14 @@ styles =
                         ]
                     ]
                 ]
+            ]
+        , class JoinRequests <|
+            [ marginBottom (px 30)
+            ]
+        , class JoinRequest <|
+            [ padding (px 5)
+            , backgroundColor primaryBlue
+            , lightTextColor
+            , marginBottom (px 8)
             ]
         ]

--- a/src/app/Groups/Update.elm
+++ b/src/app/Groups/Update.elm
@@ -3,7 +3,7 @@ module Groups.Update exposing (init, update)
 import Common.IdentifiedList exposing (mapIfId)
 import Common.Response as Response exposing (Response(..))
 import Groups.Model as Groups exposing (Model, Msg(..))
-import Groups.Ports exposing (acceptJoinRequest, createJoinGroupRequest, groupsList)
+import Groups.Ports exposing (createJoinGroupRequest, groupsList, respondJoinRequest)
 import Model as Root exposing (Msg(..))
 import Return exposing (Return, return)
 import UrlRouter.Model exposing (Msg(..))
@@ -47,7 +47,7 @@ updateGroups msg model =
                 (updateGroup groupId (\group -> { group | joinRequest = response }) model)
                 Cmd.none
 
-        AcceptJoinRequest groupId userId ->
+        RespondJoinRequest groupId userId accepted ->
             return
                 (updateGroup groupId
                     (updateJoinRequest userId
@@ -55,9 +55,9 @@ updateGroups msg model =
                     )
                     model
                 )
-                (acceptJoinRequest { groupId = groupId, userId = userId })
+                (respondJoinRequest { groupId = groupId, userId = userId, accepted = accepted })
 
-        AcceptJoinRequestResponse groupId userId response ->
+        RespondJoinRequestResponse groupId userId response ->
             return
                 (updateGroup groupId
                     (updateJoinRequest userId

--- a/src/app/Groups/Update.elm
+++ b/src/app/Groups/Update.elm
@@ -5,7 +5,7 @@ import Common.Response as Response exposing (Response(..))
 import Groups.Model as Groups exposing (Model, Msg(..))
 import Groups.Ports exposing (..)
 import Model as Root exposing (Msg(..))
-import Return exposing (Return, return)
+import Return exposing (Return, command, return)
 import UrlRouter.Model exposing (Msg(..))
 import UrlRouter.Routes exposing (Page(..), pathParser)
 
@@ -24,13 +24,14 @@ update msg model =
         MsgForUrlRouter (UrlChange location) ->
             case pathParser location of
                 Just GroupsListPage ->
-                    if model.groups == Empty then
-                        return { model | groups = Loading } (groupsList ())
-                    else
-                        return model Cmd.none
+                    fetchGroups model
+
+                Just (GroupDetailsPage _) ->
+                    fetchGroups model
 
                 Just (RidesListPage groupId) ->
-                    return model (joinRequestsList { groupId = groupId })
+                    fetchGroups model
+                        |> command (joinRequestsList { groupId = groupId })
 
                 _ ->
                     return model Cmd.none
@@ -79,6 +80,14 @@ updateGroups msg model =
                     model
                 )
                 Cmd.none
+
+
+fetchGroups : Model -> Return Groups.Msg Model
+fetchGroups model =
+    if model.groups == Empty then
+        return { model | groups = Loading } (groupsList ())
+    else
+        return model Cmd.none
 
 
 updateGroup : String -> (Groups.Group -> Groups.Group) -> Model -> Model

--- a/src/app/Groups/Update.elm
+++ b/src/app/Groups/Update.elm
@@ -21,7 +21,7 @@ update msg model =
             updateGroups msg_ model
 
         MsgForUrlRouter (UrlChange location) ->
-            if model.groups == Empty && pathParser location == Just GroupsPage then
+            if model.groups == Empty && pathParser location == Just GroupsListPage then
                 return { model | groups = Loading } (groupsList ())
             else
                 return model Cmd.none

--- a/src/app/Groups/Update.elm
+++ b/src/app/Groups/Update.elm
@@ -1,8 +1,9 @@
 module Groups.Update exposing (init, update)
 
-import Common.Response exposing (Response(..))
+import Common.IdentifiedList exposing (mapIfId)
+import Common.Response as Response exposing (Response(..))
 import Groups.Model as Groups exposing (Model, Msg(..))
-import Groups.Ports exposing (groupsList)
+import Groups.Ports exposing (createJoinGroupRequest, groupsList)
 import Model as Root exposing (Msg(..))
 import Return exposing (Return, return)
 import UrlRouter.Model exposing (Msg(..))
@@ -35,3 +36,21 @@ updateGroups msg model =
     case msg of
         UpdateGroups response ->
             return { model | groups = response } Cmd.none
+
+        CreateJoinGroupRequest groupId ->
+            return
+                (updateGroup groupId (\group -> { group | joinRequest = Loading }) model)
+                (createJoinGroupRequest { groupId = groupId })
+
+        CreateJoinGroupRequestResponse groupId response ->
+            return
+                (updateGroup groupId (\group -> { group | joinRequest = response }) model)
+                Cmd.none
+
+
+updateGroup : String -> (Groups.Group -> Groups.Group) -> Model -> Model
+updateGroup groupId updateFn model =
+    { model
+        | groups =
+            Response.map (mapIfId groupId updateFn identity) model.groups
+    }

--- a/src/app/Groups/View/Details.elm
+++ b/src/app/Groups/View/Details.elm
@@ -1,10 +1,11 @@
 module Groups.View.Details exposing (details)
 
+import Common.Form exposing (loadingOrSubmitButton)
 import Common.IdentifiedList exposing (findById)
 import Common.Response as Response exposing (Response(..))
 import Groups.Model exposing (Msg(..))
 import Html exposing (..)
-import Html.Attributes exposing (..)
+import Html.Attributes exposing (disabled)
 import Html.Events exposing (..)
 import Layout.Styles exposing (Classes(..), layoutClass)
 import Model as Root exposing (Msg(..))
@@ -35,22 +36,15 @@ renderGroup : Groups.Model.Group -> Html Root.Msg
 renderGroup group =
     div [ layoutClass Container ]
         [ h1 [ layoutClass PageTitle ] [ text group.name ]
-        , text "Você não faz parte desse grupo."
-        , button
-            [ id "joinGroup"
-            , onClick <| MsgForGroups <| CreateJoinGroupRequest group.id
+        , form [ layoutClass Card, onSubmit (MsgForGroups <| CreateJoinGroupRequest group.id) ]
+            [ p [] [ text "Este grupo é um grupo fechado, clique abaixo para pedir autorização dos administradores para entrar no grupo." ]
+            , br [] []
+            , case group.joinRequest of
+                Success _ ->
+                    button [ disabled True, layoutClass DisabledButton ]
+                        [ div [ layoutClass ButtonContainer ] [ text "Pedido enviado!" ] ]
+
+                _ ->
+                    loadingOrSubmitButton group.joinRequest "joinGroup" [ text "Participar do grupo" ]
             ]
-            [ text "Participar do grupo" ]
-        , case group.joinRequest of
-            Empty ->
-                text ""
-
-            Loading ->
-                text "Carregando..."
-
-            Success _ ->
-                text "Pedido enviado!"
-
-            Error err ->
-                text err
         ]

--- a/src/app/Groups/View/Details.elm
+++ b/src/app/Groups/View/Details.elm
@@ -15,7 +15,7 @@ details : String -> Root.Model -> Html Root.Msg
 details groupId { groups } =
     case groups.groups of
         Empty ->
-            text "TODO: fetch groups"
+            text ""
 
         Loading ->
             text "Carregando..."

--- a/src/app/Groups/View/Details.elm
+++ b/src/app/Groups/View/Details.elm
@@ -1,0 +1,10 @@
+module Groups.View.Details exposing (details)
+
+import Groups.Model exposing (Model)
+import Html exposing (..)
+import Model as Root exposing (Msg(..))
+
+
+details : Model -> Html Root.Msg
+details model =
+    text "Você não faz parte desse grupo. [Participar do grupo]"

--- a/src/app/Groups/View/Details.elm
+++ b/src/app/Groups/View/Details.elm
@@ -1,10 +1,31 @@
 module Groups.View.Details exposing (details)
 
-import Groups.Model exposing (Model)
+import Common.IdentifiedList exposing (findById)
+import Common.Response as Response exposing (Response(..))
 import Html exposing (..)
+import Layout.Styles exposing (Classes(..), layoutClass)
 import Model as Root exposing (Msg(..))
 
 
-details : Model -> Html Root.Msg
-details model =
-    text "Você não faz parte desse grupo. [Participar do grupo]"
+details : String -> Root.Model -> Html Msg
+details groupId { groups } =
+    case groups.groups of
+        Empty ->
+            text "TODO: fetch groups"
+
+        Loading ->
+            text "Carregando..."
+
+        Success groups ->
+            case findById groupId groups of
+                Just group ->
+                    div [ layoutClass Container ]
+                        [ h1 [ layoutClass PageTitle ] [ text group.name ]
+                        , text "Você não faz parte desse grupo. [Participar do grupo]"
+                        ]
+
+                Nothing ->
+                    h1 [] [ text "404 não encontrado" ]
+
+        Error err ->
+            text err

--- a/src/app/Groups/View/Details.elm
+++ b/src/app/Groups/View/Details.elm
@@ -2,12 +2,15 @@ module Groups.View.Details exposing (details)
 
 import Common.IdentifiedList exposing (findById)
 import Common.Response as Response exposing (Response(..))
+import Groups.Model exposing (Msg(..))
 import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
 import Layout.Styles exposing (Classes(..), layoutClass)
 import Model as Root exposing (Msg(..))
 
 
-details : String -> Root.Model -> Html Msg
+details : String -> Root.Model -> Html Root.Msg
 details groupId { groups } =
     case groups.groups of
         Empty ->
@@ -19,13 +22,35 @@ details groupId { groups } =
         Success groups ->
             case findById groupId groups of
                 Just group ->
-                    div [ layoutClass Container ]
-                        [ h1 [ layoutClass PageTitle ] [ text group.name ]
-                        , text "Você não faz parte desse grupo. [Participar do grupo]"
-                        ]
+                    renderGroup group
 
                 Nothing ->
                     h1 [] [ text "404 não encontrado" ]
 
         Error err ->
             text err
+
+
+renderGroup : Groups.Model.Group -> Html Root.Msg
+renderGroup group =
+    div [ layoutClass Container ]
+        [ h1 [ layoutClass PageTitle ] [ text group.name ]
+        , text "Você não faz parte desse grupo."
+        , button
+            [ id "joinGroup"
+            , onClick <| MsgForGroups <| CreateJoinGroupRequest group.id
+            ]
+            [ text "Participar do grupo" ]
+        , case group.joinRequest of
+            Empty ->
+                text ""
+
+            Loading ->
+                text "Carregando..."
+
+            Success _ ->
+                text "Pedido enviado!"
+
+            Error err ->
+                text err
+        ]

--- a/src/app/Groups/View/JoinRequests.elm
+++ b/src/app/Groups/View/JoinRequests.elm
@@ -1,0 +1,23 @@
+module Groups.View.JoinRequests exposing (joinRequestList)
+
+import Groups.Model
+import Groups.Styles exposing (Classes(..), className)
+import Html exposing (..)
+import Model as Root exposing (Msg(..))
+
+
+joinRequestList : Groups.Model.Group -> Html Msg
+joinRequestList group =
+    div []
+        (if List.length group.joinRequests > 0 then
+            [ text "Pedidos de aprovação pendentes:"
+            , ul [ className JoinRequests ] (List.map joinRequestItem group.joinRequests ++ List.map joinRequestItem group.joinRequests)
+            ]
+         else
+            []
+        )
+
+
+joinRequestItem : Groups.Model.JoinRequest -> Html Msg
+joinRequestItem joinRequest =
+    li [ className JoinRequest ] [ text joinRequest.profile.name ]

--- a/src/app/Groups/View/JoinRequests.elm
+++ b/src/app/Groups/View/JoinRequests.elm
@@ -1,23 +1,35 @@
 module Groups.View.JoinRequests exposing (joinRequestList)
 
-import Groups.Model
+import Common.Icon exposing (icon)
+import Common.Response exposing (Response(..))
+import Groups.Model exposing (Msg(..), pendingJoinRequests)
 import Groups.Styles exposing (Classes(..), className)
 import Html exposing (..)
+import Html.Attributes exposing (id)
+import Html.Events exposing (onClick)
 import Model as Root exposing (Msg(..))
 
 
-joinRequestList : Groups.Model.Group -> Html Msg
+joinRequestList : Groups.Model.Group -> Html Root.Msg
 joinRequestList group =
     div []
-        (if List.length group.joinRequests > 0 then
+        (if List.length (pendingJoinRequests group) > 0 then
             [ text "Pedidos de aprovação pendentes:"
-            , ul [ className JoinRequests ] (List.map joinRequestItem group.joinRequests ++ List.map joinRequestItem group.joinRequests)
+            , ul [ className JoinRequests ]
+                (List.map (joinRequestItem group) (pendingJoinRequests group))
             ]
          else
             []
         )
 
 
-joinRequestItem : Groups.Model.JoinRequest -> Html Msg
-joinRequestItem joinRequest =
-    li [ className JoinRequest ] [ text joinRequest.profile.name ]
+joinRequestItem : Groups.Model.Group -> Groups.Model.JoinRequest -> Html Root.Msg
+joinRequestItem group joinRequest =
+    li [ className JoinRequest ]
+        [ text joinRequest.profile.name
+        , button
+            [ id "acceptJoinRequest"
+            , onClick (MsgForGroups <| AcceptJoinRequest group.id joinRequest.userId)
+            ]
+            [ icon "done" ]
+        ]

--- a/src/app/Groups/View/JoinRequests.elm
+++ b/src/app/Groups/View/JoinRequests.elm
@@ -27,14 +27,18 @@ joinRequestItem : Groups.Model.Group -> Groups.Model.JoinRequest -> Html Root.Ms
 joinRequestItem group joinRequest =
     li [ className JoinRequest ]
         [ text joinRequest.profile.name
-        , button
-            [ id "acceptJoinRequest"
-            , onClick (MsgForGroups <| RespondJoinRequest group.id joinRequest.userId True)
+        , div []
+            [ button
+                [ id "acceptJoinRequest"
+                , className RespondButton
+                , onClick (MsgForGroups <| RespondJoinRequest group.id joinRequest.userId True)
+                ]
+                [ icon "check" ]
+            , button
+                [ id "rejectJoinRequest"
+                , className RespondButton
+                , onClick (MsgForGroups <| RespondJoinRequest group.id joinRequest.userId False)
+                ]
+                [ icon "close" ]
             ]
-            [ icon "check" ]
-        , button
-            [ id "rejectJoinRequest"
-            , onClick (MsgForGroups <| RespondJoinRequest group.id joinRequest.userId False)
-            ]
-            [ icon "close" ]
         ]

--- a/src/app/Groups/View/JoinRequests.elm
+++ b/src/app/Groups/View/JoinRequests.elm
@@ -29,7 +29,12 @@ joinRequestItem group joinRequest =
         [ text joinRequest.profile.name
         , button
             [ id "acceptJoinRequest"
-            , onClick (MsgForGroups <| AcceptJoinRequest group.id joinRequest.userId)
+            , onClick (MsgForGroups <| RespondJoinRequest group.id joinRequest.userId True)
             ]
-            [ icon "done" ]
+            [ icon "check" ]
+        , button
+            [ id "rejectJoinRequest"
+            , onClick (MsgForGroups <| RespondJoinRequest group.id joinRequest.userId False)
+            ]
+            [ icon "close" ]
         ]

--- a/src/app/Groups/View/List.elm
+++ b/src/app/Groups/View/List.elm
@@ -1,19 +1,20 @@
 module Groups.View.List exposing (list)
 
 import Common.Response exposing (Response(..))
-import Groups.Model exposing (Group, Model)
+import Groups.Model exposing (Group, Model, isMemberOfGroup)
 import Groups.Styles exposing (Classes(..), className)
 import Html exposing (..)
 import Html.Attributes exposing (id)
 import Html.Events exposing (onClick)
 import Layout.Styles exposing (Classes(..), layoutClass)
+import Login.Model
 import Model as Root exposing (Msg(..))
 import UrlRouter.Model exposing (Msg(..))
 import UrlRouter.Routes exposing (Page(..))
 
 
-list : Model -> Html Root.Msg
-list model =
+list : Login.Model.Model -> Model -> Html Root.Msg
+list login model =
     case model.groups of
         Empty ->
             text ""
@@ -27,7 +28,7 @@ list model =
                     [ h1 [ layoutClass PageTitle ] [ text "Grupos de Carona" ]
                     ]
                 , div [ className ListContainer ]
-                    [ ul [ className List ] (List.map groupItem groups)
+                    [ ul [ className List ] (List.map (groupItem login) groups)
                     ]
                 ]
 
@@ -35,6 +36,13 @@ list model =
             text err
 
 
-groupItem : Group -> Html Root.Msg
-groupItem group =
-    li [ id group.id, onClick (MsgForUrlRouter <| Go <| RidesListPage group.id) ] [ text group.name ]
+groupItem : Login.Model.Model -> Group -> Html Root.Msg
+groupItem login group =
+    let
+        page =
+            if isMemberOfGroup login group then
+                RidesListPage group.id
+            else
+                GroupDetailsPage group.id
+    in
+    li [ id group.id, onClick (MsgForUrlRouter <| Go page) ] [ text group.name ]

--- a/src/app/Layout/View/Header.elm
+++ b/src/app/Layout/View/Header.elm
@@ -19,7 +19,7 @@ header model =
         menu model.layout
             ++ [ nav [ layoutClass Navbar ]
                     [ case model.urlRouter.page of
-                        GroupsPage ->
+                        GroupsListPage ->
                             div [] []
 
                         _ ->

--- a/src/app/Rides/View/List.elm
+++ b/src/app/Rides/View/List.elm
@@ -5,6 +5,7 @@ import Common.IdentifiedList exposing (findById)
 import Common.Link exposing (linkTo)
 import Common.Response as Response exposing (Response(..))
 import Groups.Model
+import Groups.View.JoinRequests exposing (joinRequestList)
 import Html exposing (..)
 import Layout.Styles exposing (Classes(..), layoutClass)
 import Model as Root exposing (Msg(..))
@@ -65,16 +66,6 @@ ridesList group rides =
             Error err ->
                 text err
         ]
-
-
-joinRequestList : Groups.Model.Group -> Html Msg
-joinRequestList group =
-    ul [] (List.map joinRequestItem group.joinRequests)
-
-
-joinRequestItem : Groups.Model.JoinRequest -> Html Msg
-joinRequestItem joinRequest =
-    li [] [ text joinRequest.profile.name ]
 
 
 rideItem : String -> Rides.Model -> Html Msg

--- a/src/app/Rides/View/List.elm
+++ b/src/app/Rides/View/List.elm
@@ -18,7 +18,7 @@ list : String -> Root.Model -> Html Msg
 list groupId { rides, groups } =
     case groups.groups of
         Empty ->
-            text "TODO: fetch groups"
+            text ""
 
         Loading ->
             text "Carregando..."

--- a/src/app/UrlRouter/Routes.elm
+++ b/src/app/UrlRouter/Routes.elm
@@ -3,7 +3,7 @@ module UrlRouter.Routes exposing (Page(..), pathParser, redirectTo, requiresAuth
 import Login.Model as Login exposing (isSignedIn)
 import Navigation
 import Profile.Model as Profile
-import UrlParser exposing ((</>), Parser, map, oneOf, parseHash, string)
+import UrlParser exposing ((</>), Parser, map, oneOf, parseHash, string, top)
 
 
 type Page
@@ -26,7 +26,7 @@ type Page
 pageParser : Parser (Page -> a) a
 pageParser =
     oneOf
-        [ map SplashScreenPage (static "")
+        [ map SplashScreenPage top
         , map LoginPage (static "login")
         , map PasswordStepPage (static "login" </> static "password")
         , map RegistrationPage (static "login" </> static "registration")
@@ -159,12 +159,8 @@ requiresAuthentication page =
 
 
 pathParser : Navigation.Location -> Maybe Page
-pathParser location =
-    -- This if is here due to this issue https://github.com/evancz/url-parser/issues/21
-    if location.hash == "" then
-        Just SplashScreenPage
-    else
-        parseHash pageParser location
+pathParser =
+    parseHash pageParser
 
 
 static : String -> Parser a a

--- a/src/app/UrlRouter/Routes.elm
+++ b/src/app/UrlRouter/Routes.elm
@@ -15,7 +15,8 @@ type Page
     | NotFoundPage
     | ProfilePage
     | EnableNotificationsPage
-    | GroupsPage
+    | GroupsListPage
+    | GroupDetailsPage String
     | RidesListPage String
     | RidesCreatePage String
     | RideDetailsPage String String
@@ -32,7 +33,8 @@ pageParser =
         , map PasswordResetPage (static "password-reset")
         , map ProfilePage (static "profile")
         , map EnableNotificationsPage (static "enable-notifications")
-        , map GroupsPage (static "groups")
+        , map GroupsListPage (static "groups")
+        , map GroupDetailsPage (static "groups" </> string)
         , map RidesListPage (static "groups" </> string </> static "rides")
         , map RidesCreatePage (static "groups" </> string </> static "rides" </> static "give")
         , map RideDetailsPage (static "groups" </> string </> static "rides" </> string </> static "request")
@@ -67,8 +69,11 @@ toPath page =
         EnableNotificationsPage ->
             "#/enable-notifications"
 
-        GroupsPage ->
+        GroupsListPage ->
             "#/groups"
+
+        GroupDetailsPage groupId ->
+            "#/groups/" ++ groupId
 
         RidesListPage groupId ->
             "#/groups/" ++ groupId ++ "/rides"
@@ -91,13 +96,13 @@ redirectTo returnTo profile login page =
         else
             case page of
                 SplashScreenPage ->
-                    GroupsPage
+                    GroupsListPage
 
                 LoginPage ->
-                    Maybe.withDefault GroupsPage returnTo
+                    Maybe.withDefault GroupsListPage returnTo
 
                 PasswordStepPage ->
-                    Maybe.withDefault GroupsPage returnTo
+                    Maybe.withDefault GroupsListPage returnTo
 
                 _ ->
                     page
@@ -134,7 +139,10 @@ requiresAuthentication page =
         EnableNotificationsPage ->
             True
 
-        GroupsPage ->
+        GroupsListPage ->
+            True
+
+        GroupDetailsPage _ ->
             True
 
         RidesListPage _ ->

--- a/src/app/UrlRouter/Update.elm
+++ b/src/app/UrlRouter/Update.elm
@@ -47,12 +47,12 @@ update msg { notifications, profile, login, urlRouter } =
 
         MsgForRides (CreateRideReponse (Success _)) ->
             if isEnabled notifications then
-                urlRouterUpdate profile login (Go GroupsPage) urlRouter
+                urlRouterUpdate profile login (Go GroupsListPage) urlRouter
             else
                 urlRouterUpdate profile login (Go EnableNotificationsPage) urlRouter
 
         MsgForProfile (ProfileResponse (Success _)) ->
-            urlRouterUpdate profile login (Go GroupsPage) urlRouter
+            urlRouterUpdate profile login (Go GroupsListPage) urlRouter
 
         _ ->
             return urlRouter Cmd.none

--- a/src/app/View.elm
+++ b/src/app/View.elm
@@ -59,8 +59,8 @@ view model =
         GroupsListPage ->
             layout model (Groups.View.List.list model.login model.groups)
 
-        GroupDetailsPage _ ->
-            layout model (Groups.View.Details.details model.groups)
+        GroupDetailsPage groupId ->
+            layout model (Groups.View.Details.details groupId model)
 
         RideRequestDetailsPage _ _ _ _ ->
             layout model (details model.ridesRequests)

--- a/src/app/View.elm
+++ b/src/app/View.elm
@@ -1,5 +1,6 @@
 module View exposing (staticView, view)
 
+import Groups.View.Details
 import Groups.View.List
 import Html exposing (div, h1, text)
 import Layout.View.Layout exposing (layout)
@@ -55,8 +56,11 @@ view model =
         ProfilePage ->
             layout model (Html.map MsgForProfile <| profile model.profile)
 
-        GroupsPage ->
-            layout model (Groups.View.List.list model.groups)
+        GroupsListPage ->
+            layout model (Groups.View.List.list model.login model.groups)
+
+        GroupDetailsPage _ ->
+            layout model (Groups.View.Details.details model.groups)
 
         RideRequestDetailsPage _ _ _ _ ->
             layout model (details model.ridesRequests)

--- a/src/js/firebase/groups.js
+++ b/src/js/firebase/groups.js
@@ -17,15 +17,31 @@ module.exports = function(firebase, app) {
       });
   });
 
+  app.ports.joinRequestsList.subscribe(function(request) {
+    firebase
+      .database()
+      .ref("joinGroupRequests/" + request.groupId)
+      .once("value")
+      .then(function(joinGroupRequests) {
+        app.ports.joinRequestsListResponse.send({
+          groupId: request.groupId,
+          response: success(joinGroupRequests.val())
+        });
+      })
+      .catch(function(err) {
+        app.ports.joinRequestsListResponse.send(error(err.message));
+      });
+  });
+
   app.ports.createJoinGroupRequest.subscribe(function(joinGroupRequest) {
     getProfile()
       .then(function(profile) {
         return firebase
           .database()
           .ref(
-            "groups/" +
+            "joinGroupRequests/" +
               joinGroupRequest.groupId +
-              "/joinRequests/" +
+              "/" +
               firebase.auth().currentUser.uid
           )
           .set({ profile: profile.val() });
@@ -48,9 +64,9 @@ module.exports = function(firebase, app) {
     firebase
       .database()
       .ref(
-        "groups/" +
+        "joinGroupRequests/" +
           joinRequestResponse.groupId +
-          "/joinRequests/" +
+          "/" +
           joinRequestResponse.userId
       )
       .remove()

--- a/src/js/firebase/groups.js
+++ b/src/js/firebase/groups.js
@@ -23,9 +23,9 @@ module.exports = function(firebase, app) {
         return firebase
           .database()
           .ref(
-            "joinGroupRequests/" +
+            "groups/" +
               joinGroupRequest.groupId +
-              "/" +
+              "/joinRequests/" +
               firebase.auth().currentUser.uid
           )
           .set({ profile: profile.val() });

--- a/src/js/firebase/groups.js
+++ b/src/js/firebase/groups.js
@@ -2,6 +2,8 @@ var success = require("./helpers").success;
 var error = require("./helpers").error;
 
 module.exports = function(firebase, app) {
+  var getProfile = require("./profile").getProfile(firebase, app);
+
   app.ports.groupsList.subscribe(function() {
     firebase
       .database()
@@ -12,6 +14,33 @@ module.exports = function(firebase, app) {
       })
       .catch(function(err) {
         app.ports.groupsListResponse.send(error(err.message));
+      });
+  });
+
+  app.ports.createJoinGroupRequest.subscribe(function(joinGroupRequest) {
+    getProfile()
+      .then(function(profile) {
+        return firebase
+          .database()
+          .ref(
+            "joinGroupRequests/" +
+              joinGroupRequest.groupId +
+              "/" +
+              firebase.auth().currentUser.uid
+          )
+          .set({ profile: profile.val() });
+      })
+      .then(function() {
+        app.ports.createJoinGroupRequestResponse.send({
+          groupId: joinGroupRequest.groupId,
+          response: success(true)
+        });
+      })
+      .catch(function(err) {
+        app.ports.createJoinGroupRequestResponse.send({
+          groupId: joinGroupRequest.groupId,
+          response: error(err.message)
+        });
       });
   });
 };

--- a/tests/Fuzz/UrlRouter/UpdateSpec.elm
+++ b/tests/Fuzz/UrlRouter/UpdateSpec.elm
@@ -63,7 +63,7 @@ profileSample =
 
 pages : Array Page
 pages =
-    fromList [ SplashScreenPage, LoginPage, GroupsPage, NotFoundPage ]
+    fromList [ SplashScreenPage, LoginPage, GroupsListPage, NotFoundPage ]
 
 
 randomPage : Fuzzer Page

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -99,10 +99,10 @@ fixtures =
             { groupId = "idGroup1", origin = "bar", destination = "baz, near qux", days = "Mon to Fri", hours = "18:30" }
 
         group1 =
-            { id = "idGroup1", name = "winona riders", users = [ "idUser1" ], joinRequest = Empty }
+            { id = "idGroup1", name = "winona riders", members = [ { userId = "idUser1", admin = True } ], joinRequest = Empty }
 
         group2 =
-            { id = "idGroup2", name = "the uber killars", users = [], joinRequest = Empty }
+            { id = "idGroup2", name = "the uber killars", members = [], joinRequest = Empty }
 
         groups =
             [ group1, group2 ]

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -99,10 +99,10 @@ fixtures =
             { groupId = "idGroup1", origin = "bar", destination = "baz, near qux", days = "Mon to Fri", hours = "18:30" }
 
         group1 =
-            { id = "idGroup1", name = "winona riders", members = [ { userId = "idUser1", admin = True } ], joinRequest = Empty, joinRequests = [] }
+            { id = "idGroup1", name = "winona riders", members = [ { userId = "idUser1", admin = True } ], joinRequest = Empty, joinRequests = Empty }
 
         group2 =
-            { id = "idGroup2", name = "the uber killars", members = [], joinRequest = Empty, joinRequests = [] }
+            { id = "idGroup2", name = "the uber killars", members = [], joinRequest = Empty, joinRequests = Empty }
 
         groups =
             [ group1, group2 ]

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -99,10 +99,10 @@ fixtures =
             { groupId = "idGroup1", origin = "bar", destination = "baz, near qux", days = "Mon to Fri", hours = "18:30" }
 
         group1 =
-            { id = "idGroup1", name = "winona riders" }
+            { id = "idGroup1", name = "winona riders", users = [ "idUser1" ] }
 
         group2 =
-            { id = "idGroup2", name = "the uber killars" }
+            { id = "idGroup2", name = "the uber killars", users = [] }
 
         groups =
             [ group1, group2 ]

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -87,7 +87,7 @@ fixtures =
             { id = "idUser1" }
 
         profile =
-            { name = "foo", contact = { kind = "Whatsapp", value = "passenger-wpp" } }
+            { name = "fulano", contact = { kind = "Whatsapp", value = "passenger-wpp" } }
 
         ride1 =
             { id = "idRide1", groupId = "idGroup1", userId = "isUser1", origin = "bar", destination = "baz, near qux", days = "Mon to Fri", hours = "18:30", profile = { name = "foo", contact = { kind = "Whatsapp", value = "+5551" } } }
@@ -99,10 +99,10 @@ fixtures =
             { groupId = "idGroup1", origin = "bar", destination = "baz, near qux", days = "Mon to Fri", hours = "18:30" }
 
         group1 =
-            { id = "idGroup1", name = "winona riders", members = [ { userId = "idUser1", admin = True } ], joinRequest = Empty }
+            { id = "idGroup1", name = "winona riders", members = [ { userId = "idUser1", admin = True } ], joinRequest = Empty, joinRequests = [] }
 
         group2 =
-            { id = "idGroup2", name = "the uber killars", members = [], joinRequest = Empty }
+            { id = "idGroup2", name = "the uber killars", members = [], joinRequest = Empty, joinRequests = [] }
 
         groups =
             [ group1, group2 ]

--- a/tests/Helpers.elm
+++ b/tests/Helpers.elm
@@ -99,10 +99,10 @@ fixtures =
             { groupId = "idGroup1", origin = "bar", destination = "baz, near qux", days = "Mon to Fri", hours = "18:30" }
 
         group1 =
-            { id = "idGroup1", name = "winona riders", users = [ "idUser1" ] }
+            { id = "idGroup1", name = "winona riders", users = [ "idUser1" ], joinRequest = Empty }
 
         group2 =
-            { id = "idGroup2", name = "the uber killars", users = [] }
+            { id = "idGroup2", name = "the uber killars", users = [], joinRequest = Empty }
 
         groups =
             [ group1, group2 ]

--- a/tests/Integration/GroupsSpec.elm
+++ b/tests/Integration/GroupsSpec.elm
@@ -80,7 +80,27 @@ tests =
 
 loadGroups : TestContext model msg -> TestContext model msg
 loadGroups =
-    send groupsListResponse ( Nothing, Just <| simpleStringify { idGroup1 = fixtures.group1, idGroup2 = fixtures.group2 } )
+    let
+        group1 =
+            fixtures.group1
+
+        group2 =
+            fixtures.group2
+
+        group1Denormalized =
+            { group1 | members = { idUser1 = { admin = True } } }
+
+        group2Denormalized =
+            { group2 | members = {} }
+    in
+    send groupsListResponse
+        ( Nothing
+        , Just <|
+            simpleStringify
+                { idGroup1 = group1Denormalized
+                , idGroup2 = group2Denormalized
+                }
+        )
 
 
 groupsContext : a -> TestContext Model Root.Msg

--- a/tests/Integration/GroupsSpec.elm
+++ b/tests/Integration/GroupsSpec.elm
@@ -52,9 +52,7 @@ tests =
                     >> expectView
                     >> has [ text "Carregando..." ]
             , test "renders group details after loading" <|
-                groupsContext
-                    >> navigate (toPath <| GroupDetailsPage "idGroup2")
-                    >> loadGroups
+                groupDetailsContext
                     >> expectView
                     >> has [ text fixtures.group2.name ]
             , test "renders a 404 if the group was not found" <|
@@ -63,6 +61,19 @@ tests =
                     >> loadGroups
                     >> expectView
                     >> has [ text "404 não encontrado" ]
+            , test "asks for joining the group" <|
+                groupDetailsContext
+                    >> simulate (find [ id "joinGroup" ]) click
+                    >> Expect.all
+                        [ expectView >> has [ text "Carregando..." ]
+                        , expectCmd (Cmd.map MsgForGroups <| Groups.Ports.createJoinGroupRequest { groupId = "idGroup2" })
+                        ]
+            , test "shows that the join request was sent" <|
+                groupDetailsContext
+                    >> simulate (find [ id "joinGroup" ]) click
+                    >> send createJoinGroupRequestResponse { groupId = "idGroup2", response = ( Nothing, Just <| simpleStringify True ) }
+                    >> expectView
+                    >> has [ text "Pedido enviado!" ]
             ]
         ]
 
@@ -75,3 +86,10 @@ loadGroups =
 groupsContext : a -> TestContext Model Root.Msg
 groupsContext =
     signedInContext GroupsListPage
+
+
+groupDetailsContext : a -> TestContext Model Root.Msg
+groupDetailsContext =
+    groupsContext
+        >> navigate (toPath <| GroupDetailsPage "idGroup2")
+        >> loadGroups

--- a/tests/Integration/GroupsSpec.elm
+++ b/tests/Integration/GroupsSpec.elm
@@ -1,4 +1,4 @@
-module Integration.GroupsSpec exposing (tests)
+module Integration.GroupsSpec exposing (loadGroups, tests)
 
 import Expect
 import Groups.Ports exposing (..)
@@ -75,6 +75,14 @@ tests =
                     >> expectView
                     >> has [ text "Pedido enviado!" ]
             ]
+        , describe "group join requests"
+            [ test "shows the join requests" <|
+                groupsContext
+                    >> loadGroups
+                    >> simulate (find [ id "idGroup1" ]) click
+                    >> expectView
+                    >> has [ text fixtures.profile.name ]
+            ]
         ]
 
 
@@ -88,10 +96,17 @@ loadGroups =
             fixtures.group2
 
         group1Denormalized =
-            { group1 | members = { idUser1 = { admin = True } } }
+            { group1
+                | members =
+                    { idUser1 = { admin = True }
+                    }
+                , joinRequests =
+                    { idUser2 = { profile = fixtures.profile }
+                    }
+            }
 
         group2Denormalized =
-            { group2 | members = {} }
+            { name = group2.name }
     in
     send groupsListResponse
         ( Nothing

--- a/tests/Integration/GroupsSpec.elm
+++ b/tests/Integration/GroupsSpec.elm
@@ -10,7 +10,7 @@ import Test.Html.Event exposing (click)
 import Test.Html.Query exposing (..)
 import Test.Html.Selector exposing (..)
 import TestContext exposing (..)
-import UrlRouter.Routes exposing (Page(..))
+import UrlRouter.Routes exposing (Page(..), toPath)
 
 
 tests : Test
@@ -45,6 +45,25 @@ tests =
                 >> simulate (find [ id "idGroup2" ]) click
                 >> expectView
                 >> has [ text "Participar do grupo" ]
+        , describe "details"
+            [ test "shows loading when the groups are loading" <|
+                groupsContext
+                    >> navigate (toPath <| GroupDetailsPage "idGroup2")
+                    >> expectView
+                    >> has [ text "Carregando..." ]
+            , test "renders group details after loading" <|
+                groupsContext
+                    >> navigate (toPath <| GroupDetailsPage "idGroup2")
+                    >> loadGroups
+                    >> expectView
+                    >> has [ text fixtures.group2.name ]
+            , test "renders a 404 if the group was not found" <|
+                groupsContext
+                    >> navigate (toPath <| GroupDetailsPage "nan")
+                    >> loadGroups
+                    >> expectView
+                    >> has [ text "404 não encontrado" ]
+            ]
         ]
 
 

--- a/tests/Integration/GroupsSpec.elm
+++ b/tests/Integration/GroupsSpec.elm
@@ -87,18 +87,27 @@ tests =
                         [ expectView
                             >> findAll [ text fixtures.profile.name ]
                             >> count (Expect.equal 0)
-                        , expectCmd (Cmd.map MsgForGroups <| Groups.Ports.acceptJoinRequest { groupId = "idGroup1", userId = "idUser2" })
+                        , expectCmd (Cmd.map MsgForGroups <| Groups.Ports.respondJoinRequest { groupId = "idGroup1", userId = "idUser2", accepted = True })
+                        ]
+            , test "rejects join requests, hiding it" <|
+                joinRequestsContext
+                    >> simulate (find [ id "rejectJoinRequest" ]) click
+                    >> Expect.all
+                        [ expectView
+                            >> findAll [ text fixtures.profile.name ]
+                            >> count (Expect.equal 0)
+                        , expectCmd (Cmd.map MsgForGroups <| Groups.Ports.respondJoinRequest { groupId = "idGroup1", userId = "idUser2", accepted = False })
                         ]
             , test "shows join requests again when there is an error" <|
                 joinRequestsContext
                     >> simulate (find [ id "acceptJoinRequest" ]) click
-                    >> send acceptJoinRequestResponse { groupId = "idGroup1", userId = "idUser2", response = ( Just "Error", Nothing ) }
+                    >> send respondJoinRequestResponse { groupId = "idGroup1", userId = "idUser2", response = ( Just "Error", Nothing ) }
                     >> expectView
                     >> has [ text fixtures.profile.name ]
             , test "hides successfull join requests" <|
                 joinRequestsContext
                     >> simulate (find [ id "acceptJoinRequest" ]) click
-                    >> send acceptJoinRequestResponse { groupId = "idGroup1", userId = "idUser2", response = ( Nothing, Just <| simpleStringify True ) }
+                    >> send respondJoinRequestResponse { groupId = "idGroup1", userId = "idUser2", response = ( Nothing, Just <| simpleStringify True ) }
                     >> expectView
                     >> findAll [ text fixtures.profile.name ]
                     >> count (Expect.equal 0)

--- a/tests/Integration/GroupsSpec.elm
+++ b/tests/Integration/GroupsSpec.elm
@@ -6,7 +6,7 @@ import Helpers exposing (expectToContainText, fixtures, initialContext, jsonQuot
 import JsonStringify exposing (simpleStringify)
 import Model as Root exposing (Model, Msg(..))
 import Test exposing (..)
-import Test.Html.Event exposing (click)
+import Test.Html.Event exposing (click, submit)
 import Test.Html.Query exposing (..)
 import Test.Html.Selector exposing (..)
 import TestContext exposing (..)
@@ -63,14 +63,14 @@ tests =
                     >> has [ text "404 não encontrado" ]
             , test "asks for joining the group" <|
                 groupDetailsContext
-                    >> simulate (find [ id "joinGroup" ]) click
+                    >> simulate (find [ tag "form" ]) submit
                     >> Expect.all
                         [ expectView >> has [ text "Carregando..." ]
                         , expectCmd (Cmd.map MsgForGroups <| Groups.Ports.createJoinGroupRequest { groupId = "idGroup2" })
                         ]
             , test "shows that the join request was sent" <|
                 groupDetailsContext
-                    >> simulate (find [ id "joinGroup" ]) click
+                    >> simulate (find [ tag "form" ]) submit
                     >> send createJoinGroupRequestResponse { groupId = "idGroup2", response = ( Nothing, Just <| simpleStringify True ) }
                     >> expectView
                     >> has [ text "Pedido enviado!" ]

--- a/tests/Integration/GroupsSpec.elm
+++ b/tests/Integration/GroupsSpec.elm
@@ -39,6 +39,12 @@ tests =
                     (\model ->
                         Expect.equal (RidesListPage "idGroup1") model.urlRouter.page
                     )
+        , test "goes to a page requesting to join the group if the user is not a member" <|
+            groupsContext
+                >> loadGroups
+                >> simulate (find [ id "idGroup2" ]) click
+                >> expectView
+                >> has [ text "Participar do grupo" ]
         ]
 
 
@@ -49,4 +55,4 @@ loadGroups =
 
 groupsContext : a -> TestContext Model Root.Msg
 groupsContext =
-    signedInContext GroupsPage
+    signedInContext GroupsListPage

--- a/tests/Integration/GroupsSpec.elm
+++ b/tests/Integration/GroupsSpec.elm
@@ -16,8 +16,14 @@ import UrlRouter.Routes exposing (Page(..), toPath)
 tests : Test
 tests =
     describe "Groups"
-        [ test "request groups list when going to the page" <|
+        [ test "fetch groups when going to the groups list page" <|
             groupsContext
+                >> expectCmd (groupsList ())
+        , test "fetch groups when going to the groups detail page" <|
+            signedInContext (GroupDetailsPage "idGroup1")
+                >> expectCmd (groupsList ())
+        , test "fetch groups when going to the rides page" <|
+            signedInContext (RidesListPage "idGroup1")
                 >> expectCmd (groupsList ())
         , test "shows loading when the groups are loading" <|
             groupsContext

--- a/tests/Integration/LayoutSpec.elm
+++ b/tests/Integration/LayoutSpec.elm
@@ -36,26 +36,26 @@ tests =
                 >> count (Expect.equal 0)
         , test "does not have a back button on groups page" <|
             layoutContext
-                >> navigate (toPath GroupsPage)
+                >> navigate (toPath GroupsListPage)
                 >> expectView
                 >> findAll [ class NavBack ]
                 >> count (Expect.equal 0)
         , test "has a back button when on others pages" <|
             layoutContext
-                >> navigate (toPath GroupsPage)
+                >> navigate (toPath GroupsListPage)
                 >> navigate (toPath ProfilePage)
                 >> simulate (find [ class NavBack ]) click
                 >> expectModel
                     (\model ->
                         model.urlRouter.page
-                            |> Expect.equal GroupsPage
+                            |> Expect.equal GroupsListPage
                     )
         ]
 
 
 layoutContext : a -> TestContext Model Root.Msg
 layoutContext =
-    signedInContext GroupsPage
+    signedInContext GroupsListPage
 
 
 class : Classes -> Selector

--- a/tests/Integration/LoginSpec.elm
+++ b/tests/Integration/LoginSpec.elm
@@ -61,7 +61,7 @@ tests =
             , test "goes to groups page after sign in" <|
                 submitEmailThenPassword
                     >> successSignIn
-                    >> expectCurrentPage GroupsPage
+                    >> expectCurrentPage GroupsListPage
             ]
         , describe "logout"
             [ test "removes the signed in user" <|

--- a/tests/Integration/NotificationsSpec.elm
+++ b/tests/Integration/NotificationsSpec.elm
@@ -37,12 +37,12 @@ tests =
                 >> has [ text "Notificações ativadas" ]
         , describe "notices"
             [ test "shows notice" <|
-                signedInContext GroupsPage
+                signedInContext GroupsListPage
                     >> update (MsgForNotifications <| ShowNotice "banana!")
                     >> expectView
                     >> has [ text "banana!" ]
             , test "hides notice after 3 seconds" <|
-                signedInContext GroupsPage
+                signedInContext GroupsListPage
                     >> update (MsgForNotifications <| ShowNotice "banana!")
                     >> advanceTime (3 * Time.second)
                     >> expectView

--- a/tests/Integration/ProfileSpec.elm
+++ b/tests/Integration/ProfileSpec.elm
@@ -46,7 +46,7 @@ tests =
                 >> successResponse
                 >> expectModel
                     (\model ->
-                        Expect.equal GroupsPage model.urlRouter.page
+                        Expect.equal GroupsListPage model.urlRouter.page
                     )
         , test "leave profile fields filled after returning to profile page" <|
             profileContext

--- a/tests/Integration/ProfileSpec.elm
+++ b/tests/Integration/ProfileSpec.elm
@@ -22,7 +22,7 @@ tests =
             fillProfile
                 >> expectView
                 >> find [ id "name" ]
-                >> has [ attribute "value" "foo" ]
+                >> has [ attribute "value" fixtures.profile.name ]
         , test "shows loading on submit" <|
             submitProfile
                 >> expectView

--- a/tests/Integration/RidesRequestsSpec.elm
+++ b/tests/Integration/RidesRequestsSpec.elm
@@ -89,7 +89,7 @@ tests =
 
 rideRequestDetails : a -> TestContext Root.Model Root.Msg
 rideRequestDetails =
-    signedInContext GroupsPage
+    signedInContext GroupsListPage
         >> navigate "#/groups/idGroup1/rides/idRide1/requests/idUser1/idRideRequest1"
 
 

--- a/tests/Integration/RidesSpec.elm
+++ b/tests/Integration/RidesSpec.elm
@@ -4,6 +4,7 @@ import Common.Response exposing (Response(..))
 import Css.Helpers exposing (identifierToString)
 import Expect exposing (equal)
 import Helpers exposing (expectCurrentPage, expectToContainText, fixtures, initialContext, signedInContext, someUser, toLocation)
+import Integration.GroupsSpec exposing (loadGroups)
 import JsonStringify exposing (simpleStringify)
 import Model as Root exposing (Model, Msg(..))
 import Notifications.Model exposing (Msg(..))
@@ -36,12 +37,14 @@ tests =
                     >> has [ text "Carregando..." ]
             , test "renders rides when they load" <|
                 ridesListContext
+                    >> loadGroups
                     >> loadRides
                     >> expectView
                     >> findAll [ class Card ]
                     >> count (Expect.equal 2)
             , test "renders only the rides for the selected group" <|
                 ridesListContext
+                    >> loadGroups
                     >> loadRides
                     >> navigate (toPath <| RidesListPage "idGroup2")
                     >> expectView

--- a/tests/Integration/RidesSpec.elm
+++ b/tests/Integration/RidesSpec.elm
@@ -75,7 +75,7 @@ tests =
                 submitNewRide
                     >> update (MsgForNotifications <| NotificationsResponse (Success True))
                     >> successResponse
-                    >> expectCurrentPage GroupsPage
+                    >> expectCurrentPage GroupsListPage
             , test "shows notification on success" <|
                 submitNewRide
                     >> successResponse

--- a/tests/Integration/UrlRouterSpec.elm
+++ b/tests/Integration/UrlRouterSpec.elm
@@ -24,9 +24,9 @@ tests =
         [ describe "initial routing"
             [ test "renders rides page if app starts on login page but user is already signed in" <|
                 signedInContext LoginPage
-                    >> expectCurrentPage GroupsPage
+                    >> expectCurrentPage GroupsListPage
             , test "renders login page if app starts on rides page but user is not signed in" <|
-                initialContext Nothing Nothing GroupsPage
+                initialContext Nothing Nothing GroupsListPage
                     >> expectToBeOnLoginPage
             , test "renders the requested page without redirect if already signed in after receiving a success sign in" <|
                 signedInContext ProfilePage
@@ -39,20 +39,20 @@ tests =
         , test "redirects user to login page if it is not signed in and goes to home or page" <|
             loginContext
                 >> Expect.all
-                    [ update (MsgForUrlRouter <| UrlChange (toLocation GroupsPage)) >> expectToBeOnLoginPage
+                    [ update (MsgForUrlRouter <| UrlChange (toLocation GroupsListPage)) >> expectToBeOnLoginPage
                     , update (MsgForUrlRouter <| UrlChange (toLocation SplashScreenPage)) >> expectToBeOnLoginPage
                     ]
         , test "renders groups and hides login when user is signed in and on groups route" <|
             loginContext
                 >> successSignIn
-                >> update (MsgForUrlRouter <| UrlChange (toLocation GroupsPage))
-                >> expectCurrentPage GroupsPage
+                >> update (MsgForUrlRouter <| UrlChange (toLocation GroupsListPage))
+                >> expectCurrentPage GroupsListPage
         , test "redirects user to groups page if it is already signed in and goes to login page or home page" <|
             loginContext
                 >> successSignIn
                 >> Expect.all
-                    [ update (MsgForUrlRouter <| UrlChange (toLocation LoginPage)) >> expectCurrentPage GroupsPage
-                    , update (MsgForUrlRouter <| UrlChange (toLocation SplashScreenPage)) >> expectCurrentPage GroupsPage
+                    [ update (MsgForUrlRouter <| UrlChange (toLocation LoginPage)) >> expectCurrentPage GroupsListPage
+                    , update (MsgForUrlRouter <| UrlChange (toLocation SplashScreenPage)) >> expectCurrentPage GroupsListPage
                     ]
         , test "returns to initial requested url after signing in" <|
             initialContext Nothing Nothing ProfilePage
@@ -64,21 +64,21 @@ tests =
                     >> expectCmd (Cmd.map MsgForLogin <| signOut ())
             , test "does not log user out until the response from firebase" <|
                 loginThenLogout
-                    >> expectCurrentPage GroupsPage
+                    >> expectCurrentPage GroupsListPage
             ]
         , test "redirect to profile page if user does not have a profile yet" <|
             loginContext
                 >> successSignInWithoutProfile
                 >> Expect.all
                     [ update (MsgForUrlRouter <| UrlChange (toLocation LoginPage)) >> expectCurrentPage ProfilePage
-                    , update (MsgForUrlRouter <| UrlChange (toLocation GroupsPage)) >> expectCurrentPage ProfilePage
+                    , update (MsgForUrlRouter <| UrlChange (toLocation GroupsListPage)) >> expectCurrentPage ProfilePage
                     ]
         , test "do not redirect to profile page after creating on" <|
             loginContext
                 >> successSignInWithoutProfile
                 >> update (MsgForProfile <| ProfileResponse (Success fixtures.profile))
-                >> update (MsgForUrlRouter <| UrlChange (toLocation GroupsPage))
-                >> expectCurrentPage GroupsPage
+                >> update (MsgForUrlRouter <| UrlChange (toLocation GroupsListPage))
+                >> expectCurrentPage GroupsListPage
         ]
 
 
@@ -101,7 +101,7 @@ loginThenLogout : a -> TestContext Model Root.Msg
 loginThenLogout =
     loginContext
         >> successSignIn
-        >> update (MsgForUrlRouter <| UrlChange (toLocation GroupsPage))
+        >> update (MsgForUrlRouter <| UrlChange (toLocation GroupsListPage))
         >> simulate (find [ id "openMenu" ]) click
         >> simulate (find [ layoutClass SignOutButton ]) click
 

--- a/tests/JsonStringify.elm
+++ b/tests/JsonStringify.elm
@@ -11,6 +11,8 @@ simpleStringify a =
     toString a
         |> replace All (regex " ([^ ]+) =") (\match -> " \"" ++ matchOrEmptyAt match 1 ++ "\":")
         |> replace All (regex ": ([A-Z].*?) ") (\_ -> ": null ")
+        |> replace All (regex "\\bTrue\\b") (\_ -> "true")
+        |> replace All (regex "\\bFalse\\b") (\_ -> "false")
         |> Json.Decode.decodeString Json.Decode.value
         |> unwrap
 

--- a/tests/JsonStringify.elm
+++ b/tests/JsonStringify.elm
@@ -10,9 +10,9 @@ simpleStringify : a -> Json.Encode.Value
 simpleStringify a =
     toString a
         |> replace All (regex " ([^ ]+) =") (\match -> " \"" ++ matchOrEmptyAt match 1 ++ "\":")
-        |> replace All (regex ": ([A-Z].*?) ") (\_ -> ": null ")
         |> replace All (regex "\\bTrue\\b") (\_ -> "true")
         |> replace All (regex "\\bFalse\\b") (\_ -> "false")
+        |> replace All (regex ": ([A-Z].*?) ") (\_ -> ": null ")
         |> Json.Decode.decodeString Json.Decode.value
         |> unwrap
 

--- a/tests/JsonStringify.elm
+++ b/tests/JsonStringify.elm
@@ -12,7 +12,7 @@ simpleStringify a =
         |> replace All (regex " ([^ ]+) =") (\match -> " \"" ++ matchOrEmptyAt match 1 ++ "\":")
         |> replace All (regex "\\bTrue\\b") (\_ -> "true")
         |> replace All (regex "\\bFalse\\b") (\_ -> "false")
-        |> replace All (regex ": ([A-Z].*?) ") (\_ -> ": null ")
+        |> replace All (regex ": ([A-Z][^ ,]*)") (\_ -> ": null")
         |> Json.Decode.decodeString Json.Decode.value
         |> unwrap
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "Fresheyeball/elm-return": "6.0.3 <= v < 7.0.0",
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
-        "xavh4/elm-testable": "1.0.0 <= v < 3.0.0",
+        "user/project": "1.0.0 <= v < 3.0.0",
         "elm-community/elm-test": "4.1.0 <= v < 5.0.0",
         "elm-community/list-extra": "6.1.0 <= v < 7.0.0",
         "elm-community/string-extra": "1.4.0 <= v < 2.0.0",
@@ -26,7 +26,7 @@
         "eeue56/elm-html-test": "4.1.0 <= v < 5.0.0"
     },
     "dependency-sources": {
-        "xavh4/elm-testable": {
+        "user/project": {
           "url": "https://github.com/rogeriochaves/elm-testable.git",
           "ref": "rewrite-native"
         }


### PR DESCRIPTION
Now groups are closed, and people have to ask permission to join:

![image](https://user-images.githubusercontent.com/792201/28920992-92f11850-782a-11e7-8954-70f2a03dbe90.png)

And the admins can approve:

![image](https://user-images.githubusercontent.com/792201/28921061-d750c054-782a-11e7-98e9-5cdd72365c08.png)
(we can work to improve this design later)

For now I'm the admin, but I'll also add @luismizutani, @taniadgv, @eduardomoroni, @ialbuqu, @viniciusrdacosta, @gustavomazevedo so you can help with the approavals. I do this change manually and directly on the database, so if you haven't sign up to caronaboard yet, do it, I need your ID.

This will finally allow us to marketing caronaboard so people at thoughtworks offices can use, while keeping their data private.

And then I'll make no further big changes on the app, so the react-native one can keep up, and I can explain more people how this elm codebase is working rather than keeping adding stuff to it.

Cheers!