### PR TITLE
Adiciona uid ao profile

### DIFF
--- a/src/js/firebase/profile.js
+++ b/src/js/firebase/profile.js
@@ -14,10 +14,12 @@ var getProfile = function(firebase, app) {
 module.exports = function(firebase, app) {
   app.ports.saveProfile.subscribe(function(profile) {
     var currentUser = firebase.auth().currentUser;
-
+    
     var pathsToUpdate = {};
     pathsToUpdate["profiles/" + currentUser.uid] = profile;
 
+    profile.uid = currentUser.uid
+    
     firebase
       .database()
       .ref("rides/" + currentUser.uid)


### PR DESCRIPTION
Relacionado a https://github.com/CaronaBoard/caronaboard/issues/67

Ao atualizar o perfil no caronaboard-native, estamos dependendo que o profile tenha um campo `uid`.